### PR TITLE
`require_audience` has changed to `target_audience`

### DIFF
--- a/docs/oathkeeper/api-access-rules.md
+++ b/docs/oathkeeper/api-access-rules.md
@@ -293,7 +293,7 @@ items are optional and ignored if left out.
         "handler": "jwt",
         "config": {
             "required_scope": ["scope-a", "scope-b"],
-            "require_audience": ["aud-1"],
+            "target_audience": ["aud-1"],
             "trusted_issuers": ["iss-1"],
         }
     }],


### PR DESCRIPTION
Please update the documentation for the jwt handler to reflect the change in the naming from `authenticators[].config.require_audience` to `authenticators[].config.target_audience` as the go handler expects `target_audience`. 

Referencing https://github.com/ory/oathkeeper/blob/master/proxy/authenticator_jwt.go Line 32.