### PR TITLE
update siteConfig.js to fix spelling error + broken link

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -45,7 +45,7 @@ const siteConfig = {
   headerLinks: [
     {href: "/", label: 'Home'},
     {href: "/blog", label: 'Blog'},
-    {href: "https://comunity.ory.sh", label: 'Forum'},
+    {href: "https://community.ory.sh", label: 'Forum'},
     {href: "/chat", label: 'Chat'},
     {doc: "index", label: 'Docs'},
     {href: "https://github.com/ory/", label: 'GitHub'},


### PR DESCRIPTION
I noticed that the forum link is sometimes broken on the site. 'community' works and is spelled correctly but 'comunity' is broken and misspelled. Hopefully fixing this spelling will also fix the broken link.