### PR TITLE
Re-export pipeline diagram from Mermaid 8.0.0

### DIFF
--- a/website/static/images/docs/oathkeeper/pipeline.svg
+++ b/website/static/images/docs/oathkeeper/pipeline.svg
@@ -1,40 +1,40 @@
-<svg id="mermaid-1557919323117" width="100%" xmlns="http://www.w3.org/2000/svg" style="max-width: 565.38671875px;" viewBox="0 0 565.38671875 584"><style>
+<svg id="mermaid-1558385692435" width="100%" xmlns="http://www.w3.org/2000/svg" style="max-width: 1426.18359375px;" viewBox="0 0 1426.18359375 942.875"><style>
 
 
-#mermaid-1557919323117 .label {
+#mermaid-1558385692435 .label {
   font-family: 'trebuchet ms', verdana, arial;
   color: #333; }
 
-#mermaid-1557919323117 .node rect,
-#mermaid-1557919323117 .node circle,
-#mermaid-1557919323117 .node ellipse,
-#mermaid-1557919323117 .node polygon {
+#mermaid-1558385692435 .node rect,
+#mermaid-1558385692435 .node circle,
+#mermaid-1558385692435 .node ellipse,
+#mermaid-1558385692435 .node polygon {
   fill: #ECECFF;
   stroke: #9370DB;
   stroke-width: 1px; }
 
-#mermaid-1557919323117 .node.clickable {
+#mermaid-1558385692435 .node.clickable {
   cursor: pointer; }
 
-#mermaid-1557919323117 .arrowheadPath {
+#mermaid-1558385692435 .arrowheadPath {
   fill: #333333; }
 
-#mermaid-1557919323117 .edgePath .path {
+#mermaid-1558385692435 .edgePath .path {
   stroke: #333333;
   stroke-width: 1.5px; }
 
-#mermaid-1557919323117 .edgeLabel {
+#mermaid-1558385692435 .edgeLabel {
   background-color: #e8e8e8; }
 
-#mermaid-1557919323117 .cluster rect {
+#mermaid-1558385692435 .cluster rect {
   fill: #ffffde !important;
   stroke: #aaaa33 !important;
   stroke-width: 1px !important; }
 
-#mermaid-1557919323117 .cluster text {
+#mermaid-1558385692435 .cluster text {
   fill: #333; }
 
-#mermaid-1557919323117 div.mermaidTooltip {
+#mermaid-1558385692435 div.mermaidTooltip {
   position: absolute;
   text-align: center;
   max-width: 200px;
@@ -47,315 +47,315 @@
   pointer-events: none;
   z-index: 100; }
 
-#mermaid-1557919323117 .actor {
+#mermaid-1558385692435 .actor {
   stroke: #CCCCFF;
   fill: #ECECFF; }
 
-#mermaid-1557919323117 text.actor {
+#mermaid-1558385692435 text.actor {
   fill: black;
   stroke: none; }
 
-#mermaid-1557919323117 .actor-line {
+#mermaid-1558385692435 .actor-line {
   stroke: grey; }
 
-#mermaid-1557919323117 .messageLine0 {
+#mermaid-1558385692435 .messageLine0 {
   stroke-width: 1.5;
   stroke-dasharray: '2 2';
   stroke: #333; }
 
-#mermaid-1557919323117 .messageLine1 {
+#mermaid-1558385692435 .messageLine1 {
   stroke-width: 1.5;
   stroke-dasharray: '2 2';
   stroke: #333; }
 
-#mermaid-1557919323117 #arrowhead {
+#mermaid-1558385692435 #arrowhead {
   fill: #333; }
 
-#mermaid-1557919323117 #crosshead path {
+#mermaid-1558385692435 #crosshead path {
   fill: #333 !important;
   stroke: #333 !important; }
 
-#mermaid-1557919323117 .messageText {
+#mermaid-1558385692435 .messageText {
   fill: #333;
   stroke: none; }
 
-#mermaid-1557919323117 .labelBox {
+#mermaid-1558385692435 .labelBox {
   stroke: #CCCCFF;
   fill: #ECECFF; }
 
-#mermaid-1557919323117 .labelText {
+#mermaid-1558385692435 .labelText {
   fill: black;
   stroke: none; }
 
-#mermaid-1557919323117 .loopText {
+#mermaid-1558385692435 .loopText {
   fill: black;
   stroke: none; }
 
-#mermaid-1557919323117 .loopLine {
+#mermaid-1558385692435 .loopLine {
   stroke-width: 2;
   stroke-dasharray: '2 2';
   stroke: #CCCCFF; }
 
-#mermaid-1557919323117 .note {
+#mermaid-1558385692435 .note {
   stroke: #aaaa33;
   fill: #fff5ad; }
 
-#mermaid-1557919323117 .noteText {
+#mermaid-1558385692435 .noteText {
   fill: black;
   stroke: none;
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px; }
 
-#mermaid-1557919323117 .activation0 {
+#mermaid-1558385692435 .activation0 {
   fill: #f4f4f4;
   stroke: #666; }
 
-#mermaid-1557919323117 .activation1 {
+#mermaid-1558385692435 .activation1 {
   fill: #f4f4f4;
   stroke: #666; }
 
-#mermaid-1557919323117 .activation2 {
+#mermaid-1558385692435 .activation2 {
   fill: #f4f4f4;
   stroke: #666; }
 
 
-#mermaid-1557919323117 .section {
+#mermaid-1558385692435 .section {
   stroke: none;
   opacity: 0.2; }
 
-#mermaid-1557919323117 .section0 {
+#mermaid-1558385692435 .section0 {
   fill: rgba(102, 102, 255, 0.49); }
 
-#mermaid-1557919323117 .section2 {
+#mermaid-1558385692435 .section2 {
   fill: #fff400; }
 
-#mermaid-1557919323117 .section1,
-#mermaid-1557919323117 .section3 {
+#mermaid-1558385692435 .section1,
+#mermaid-1558385692435 .section3 {
   fill: white;
   opacity: 0.2; }
 
-#mermaid-1557919323117 .sectionTitle0 {
+#mermaid-1558385692435 .sectionTitle0 {
   fill: #333; }
 
-#mermaid-1557919323117 .sectionTitle1 {
+#mermaid-1558385692435 .sectionTitle1 {
   fill: #333; }
 
-#mermaid-1557919323117 .sectionTitle2 {
+#mermaid-1558385692435 .sectionTitle2 {
   fill: #333; }
 
-#mermaid-1557919323117 .sectionTitle3 {
+#mermaid-1558385692435 .sectionTitle3 {
   fill: #333; }
 
-#mermaid-1557919323117 .sectionTitle {
+#mermaid-1558385692435 .sectionTitle {
   text-anchor: start;
   font-size: 11px;
   text-height: 14px; }
 
 
-#mermaid-1557919323117 .grid .tick {
+#mermaid-1558385692435 .grid .tick {
   stroke: lightgrey;
   opacity: 0.3;
   shape-rendering: crispEdges; }
 
-#mermaid-1557919323117 .grid path {
+#mermaid-1558385692435 .grid path {
   stroke-width: 0; }
 
 
-#mermaid-1557919323117 .today {
+#mermaid-1558385692435 .today {
   fill: none;
   stroke: red;
   stroke-width: 2px; }
 
 
 
-#mermaid-1557919323117 .task {
+#mermaid-1558385692435 .task {
   stroke-width: 2; }
 
-#mermaid-1557919323117 .taskText {
+#mermaid-1558385692435 .taskText {
   text-anchor: middle;
   font-size: 11px; }
 
-#mermaid-1557919323117 .taskTextOutsideRight {
+#mermaid-1558385692435 .taskTextOutsideRight {
   fill: black;
   text-anchor: start;
   font-size: 11px; }
 
-#mermaid-1557919323117 .taskTextOutsideLeft {
+#mermaid-1558385692435 .taskTextOutsideLeft {
   fill: black;
   text-anchor: end;
   font-size: 11px; }
 
 
-#mermaid-1557919323117 .taskText0,
-#mermaid-1557919323117 .taskText1,
-#mermaid-1557919323117 .taskText2,
-#mermaid-1557919323117 .taskText3 {
+#mermaid-1558385692435 .taskText0,
+#mermaid-1558385692435 .taskText1,
+#mermaid-1558385692435 .taskText2,
+#mermaid-1558385692435 .taskText3 {
   fill: white; }
 
-#mermaid-1557919323117 .task0,
-#mermaid-1557919323117 .task1,
-#mermaid-1557919323117 .task2,
-#mermaid-1557919323117 .task3 {
+#mermaid-1558385692435 .task0,
+#mermaid-1558385692435 .task1,
+#mermaid-1558385692435 .task2,
+#mermaid-1558385692435 .task3 {
   fill: #8a90dd;
   stroke: #534fbc; }
 
-#mermaid-1557919323117 .taskTextOutside0,
-#mermaid-1557919323117 .taskTextOutside2 {
+#mermaid-1558385692435 .taskTextOutside0,
+#mermaid-1558385692435 .taskTextOutside2 {
   fill: black; }
 
-#mermaid-1557919323117 .taskTextOutside1,
-#mermaid-1557919323117 .taskTextOutside3 {
+#mermaid-1558385692435 .taskTextOutside1,
+#mermaid-1558385692435 .taskTextOutside3 {
   fill: black; }
 
 
-#mermaid-1557919323117 .active0,
-#mermaid-1557919323117 .active1,
-#mermaid-1557919323117 .active2,
-#mermaid-1557919323117 .active3 {
+#mermaid-1558385692435 .active0,
+#mermaid-1558385692435 .active1,
+#mermaid-1558385692435 .active2,
+#mermaid-1558385692435 .active3 {
   fill: #bfc7ff;
   stroke: #534fbc; }
 
-#mermaid-1557919323117 .activeText0,
-#mermaid-1557919323117 .activeText1,
-#mermaid-1557919323117 .activeText2,
-#mermaid-1557919323117 .activeText3 {
+#mermaid-1558385692435 .activeText0,
+#mermaid-1558385692435 .activeText1,
+#mermaid-1558385692435 .activeText2,
+#mermaid-1558385692435 .activeText3 {
   fill: black !important; }
 
 
-#mermaid-1557919323117 .done0,
-#mermaid-1557919323117 .done1,
-#mermaid-1557919323117 .done2,
-#mermaid-1557919323117 .done3 {
+#mermaid-1558385692435 .done0,
+#mermaid-1558385692435 .done1,
+#mermaid-1558385692435 .done2,
+#mermaid-1558385692435 .done3 {
   stroke: grey;
   fill: lightgrey;
   stroke-width: 2; }
 
-#mermaid-1557919323117 .doneText0,
-#mermaid-1557919323117 .doneText1,
-#mermaid-1557919323117 .doneText2,
-#mermaid-1557919323117 .doneText3 {
+#mermaid-1558385692435 .doneText0,
+#mermaid-1558385692435 .doneText1,
+#mermaid-1558385692435 .doneText2,
+#mermaid-1558385692435 .doneText3 {
   fill: black !important; }
 
 
-#mermaid-1557919323117 .crit0,
-#mermaid-1557919323117 .crit1,
-#mermaid-1557919323117 .crit2,
-#mermaid-1557919323117 .crit3 {
+#mermaid-1558385692435 .crit0,
+#mermaid-1558385692435 .crit1,
+#mermaid-1558385692435 .crit2,
+#mermaid-1558385692435 .crit3 {
   stroke: #ff8888;
   fill: red;
   stroke-width: 2; }
 
-#mermaid-1557919323117 .activeCrit0,
-#mermaid-1557919323117 .activeCrit1,
-#mermaid-1557919323117 .activeCrit2,
-#mermaid-1557919323117 .activeCrit3 {
+#mermaid-1558385692435 .activeCrit0,
+#mermaid-1558385692435 .activeCrit1,
+#mermaid-1558385692435 .activeCrit2,
+#mermaid-1558385692435 .activeCrit3 {
   stroke: #ff8888;
   fill: #bfc7ff;
   stroke-width: 2; }
 
-#mermaid-1557919323117 .doneCrit0,
-#mermaid-1557919323117 .doneCrit1,
-#mermaid-1557919323117 .doneCrit2,
-#mermaid-1557919323117 .doneCrit3 {
+#mermaid-1558385692435 .doneCrit0,
+#mermaid-1558385692435 .doneCrit1,
+#mermaid-1558385692435 .doneCrit2,
+#mermaid-1558385692435 .doneCrit3 {
   stroke: #ff8888;
   fill: lightgrey;
   stroke-width: 2;
   cursor: pointer;
   shape-rendering: crispEdges; }
 
-#mermaid-1557919323117 .doneCritText0,
-#mermaid-1557919323117 .doneCritText1,
-#mermaid-1557919323117 .doneCritText2,
-#mermaid-1557919323117 .doneCritText3 {
+#mermaid-1558385692435 .doneCritText0,
+#mermaid-1558385692435 .doneCritText1,
+#mermaid-1558385692435 .doneCritText2,
+#mermaid-1558385692435 .doneCritText3 {
   fill: black !important; }
 
-#mermaid-1557919323117 .activeCritText0,
-#mermaid-1557919323117 .activeCritText1,
-#mermaid-1557919323117 .activeCritText2,
-#mermaid-1557919323117 .activeCritText3 {
+#mermaid-1558385692435 .activeCritText0,
+#mermaid-1558385692435 .activeCritText1,
+#mermaid-1558385692435 .activeCritText2,
+#mermaid-1558385692435 .activeCritText3 {
   fill: black !important; }
 
-#mermaid-1557919323117 .titleText {
+#mermaid-1558385692435 .titleText {
   text-anchor: middle;
   font-size: 18px;
   fill: black; }
 
-#mermaid-1557919323117 g.classGroup text {
+#mermaid-1558385692435 g.classGroup text {
   fill: #9370DB;
   stroke: none;
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 10px; }
 
-#mermaid-1557919323117 g.classGroup rect {
+#mermaid-1558385692435 g.classGroup rect {
   fill: #ECECFF;
   stroke: #9370DB; }
 
-#mermaid-1557919323117 g.classGroup line {
+#mermaid-1558385692435 g.classGroup line {
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 .classLabel .box {
+#mermaid-1558385692435 .classLabel .box {
   stroke: none;
   stroke-width: 0;
   fill: #ECECFF;
   opacity: 0.5; }
 
-#mermaid-1557919323117 .classLabel .label {
+#mermaid-1558385692435 .classLabel .label {
   fill: #9370DB;
   font-size: 10px; }
 
-#mermaid-1557919323117 .relation {
+#mermaid-1558385692435 .relation {
   stroke: #9370DB;
   stroke-width: 1;
   fill: none; }
 
-#mermaid-1557919323117 #compositionStart {
+#mermaid-1558385692435 #compositionStart {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #compositionEnd {
+#mermaid-1558385692435 #compositionEnd {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #aggregationStart {
+#mermaid-1558385692435 #aggregationStart {
   fill: #ECECFF;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #aggregationEnd {
+#mermaid-1558385692435 #aggregationEnd {
   fill: #ECECFF;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #dependencyStart {
+#mermaid-1558385692435 #dependencyStart {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #dependencyEnd {
+#mermaid-1558385692435 #dependencyEnd {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #extensionStart {
+#mermaid-1558385692435 #extensionStart {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 #extensionEnd {
+#mermaid-1558385692435 #extensionEnd {
   fill: #9370DB;
   stroke: #9370DB;
   stroke-width: 1; }
 
-#mermaid-1557919323117 .commit-id,
-#mermaid-1557919323117 .commit-msg,
-#mermaid-1557919323117 .branch-label {
+#mermaid-1558385692435 .commit-id,
+#mermaid-1558385692435 .commit-msg,
+#mermaid-1558385692435 .branch-label {
   fill: lightgrey;
   color: lightgrey; }
 
-#mermaid-1557919323117 .label foreignObject { overflow: visible; font-size: 13px }</style><style>#mermaid-1557919323117 {
+#mermaid-1558385692435 .label foreignObject { overflow: visible; font-size: 13px }</style><style>#mermaid-1558385692435 {
     color: rgba(0, 0, 0, 0.65);
     font: ;
-  }</style><g transform="translate(-12, -12)"><g class="output"><g class="clusters"></g><g class="edgePaths"><g class="edgePath" style="opacity: 1;"><path class="path" d="M187.45703125,59L187.45703125,84L187.45703125,109" marker-end="url(#arrowhead1049)" style="fill:none"></path><defs><marker id="arrowhead1049" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M220.13199573863636,148L279.6171875,183.5L279.6171875,219" marker-end="url(#arrowhead1050)" style="fill:none"></path><defs><marker id="arrowhead1050" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M154.78206676136364,148L95.296875,183.5L95.296875,219" marker-end="url(#arrowhead1051)" style="fill:none"></path><defs><marker id="arrowhead1051" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M319.0797585227273,258L390.921875,293.5L390.921875,329" marker-end="url(#arrowhead1052)" style="fill:none"></path><defs><marker id="arrowhead1052" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M240.15461647727273,258L168.3125,293.5L168.3125,329" marker-end="url(#arrowhead1053)" style="fill:none"></path><defs><marker id="arrowhead1053" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M354.74300426136364,368L288.87890625,403.5L288.87890625,439" marker-end="url(#arrowhead1054)" style="fill:none"></path><defs><marker id="arrowhead1054" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M427.10074573863636,368L492.96484375,403.5L492.96484375,439" marker-end="url(#arrowhead1055)" style="fill:none"></path><defs><marker id="arrowhead1055" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M492.96484375,478L492.96484375,513.5L492.96484375,549" marker-end="url(#arrowhead1056)" style="fill:none"></path><defs><marker id="arrowhead1056" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g></g><g class="edgeLabels"><g class="edgeLabel" style="opacity: 1;" transform=""><g transform="translate(0,0)" class="label"><foreignObject width="0" height="0"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel"></span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(279.6171875,183.5)"><g transform="translate(-89.0234375,-10.5)" class="label"><foreignObject width="178.046875" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">found matching access rule</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(95.296875,183.5)"><g transform="translate(-75.296875,-10.5)" class="label"><foreignObject width="150.59375" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">did not find access rule</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(390.921875,293.5)"><g transform="translate(-98.546875,-10.5)" class="label"><foreignObject width="197.09375" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">credentials in request are valid</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(168.3125,293.5)"><g transform="translate(-104.0625,-10.5)" class="label"><foreignObject width="208.125" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">credentials in request are invalid</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(288.87890625,403.5)"><g transform="translate(-109,-10.5)" class="label"><foreignObject width="218" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">request does not have permission</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(492.96484375,403.5)"><g transform="translate(-75.0859375,-10.5)" class="label"><foreignObject width="150.171875" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">request has permission</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(492.96484375,513.5)"><g transform="translate(-73.0546875,-10.5)" class="label"><foreignObject width="146.109375" height="21"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">transform http request</span></div></foreignObject></g></g></g><g class="nodes"><g class="node" style="opacity: 1;" id="401" transform="translate(168.3125,348.5)"><rect rx="5" ry="5" x="-54.1171875" y="-19.5" width="108.234375" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-44.1171875,-9.5)"><foreignObject width="88.234375" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 401</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="403" transform="translate(288.87890625,458.5)"><rect rx="5" ry="5" x="-54.1171875" y="-19.5" width="108.234375" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-44.1171875,-9.5)"><foreignObject width="88.234375" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 403</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="404" transform="translate(95.296875,238.5)"><rect rx="5" ry="5" x="-54.1171875" y="-19.5" width="108.234375" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-44.1171875,-9.5)"><foreignObject width="88.234375" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 404</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="r" transform="translate(187.45703125,39.5)"><rect rx="5" ry="5" x="-50.640625" y="-19.5" width="101.28125" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-40.640625,-9.5)"><foreignObject width="81.28125" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Request</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="arm" transform="translate(187.45703125,128.5)"><rect rx="5" ry="5" x="-69.2421875" y="-19.5" width="138.484375" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-59.2421875,-9.5)"><foreignObject width="118.484375" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Access Rule Matcher</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="an" transform="translate(279.6171875,238.5)"><rect rx="5" ry="5" x="-50.2734375" y="-19.5" width="100.546875" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-40.2734375,-9.5)"><foreignObject width="80.546875" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Authenticator</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="az" transform="translate(390.921875,348.5)"><rect rx="5" ry="5" x="-40.5390625" y="-19.5" width="81.078125" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-30.5390625,-9.5)"><foreignObject width="61.078125" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Authorizer</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="mt" transform="translate(492.96484375,458.5)"><rect rx="5" ry="5" x="-32.75" y="-19.5" width="65.5" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-22.75,-9.5)"><foreignObject width="45.5" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Mutator</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="res" transform="translate(492.96484375,568.5)"><rect rx="5" ry="5" x="-76.421875" y="-19.5" width="152.84375" height="39"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-66.421875,-9.5)"><foreignObject width="132.84375" height="19"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Forward HTTP Request</div></foreignObject></g></g></g></g></g></g></svg>
+  }</style><g transform="translate(-12, -12)"><g class="output"><g class="clusters"></g><g class="edgePaths"><g class="edgePath" style="opacity: 1;"><path class="path" d="M451.8984375,93.4375L451.8984375,118.4375L451.8984375,143.4375" marker-end="url(#arrowhead37)" style="fill:none"></path><defs><marker id="arrowhead37" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M544.6604371789383,216.875L682.421875,271.40625L682.421875,325.9375" marker-end="url(#arrowhead38)" style="fill:none"></path><defs><marker id="arrowhead38" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M359.13643782106163,216.875L221.375,271.40625L221.375,325.9375" marker-end="url(#arrowhead39)" style="fill:none"></path><defs><marker id="arrowhead39" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M796.9793450342465,399.375L967.109375,453.90625L967.109375,508.4375" marker-end="url(#arrowhead40)" style="fill:none"></path><defs><marker id="arrowhead40" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M567.8644049657535,399.375L397.734375,453.90625L397.734375,508.4375" marker-end="url(#arrowhead41)" style="fill:none"></path><defs><marker id="arrowhead41" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M871.21875,578.8724774034047L707.58984375,636.40625L707.58984375,690.9375" marker-end="url(#arrowhead42)" style="fill:none"></path><defs><marker id="arrowhead42" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M1063,578.8724774034047L1226.62890625,636.40625L1226.62890625,690.9375" marker-end="url(#arrowhead43)" style="fill:none"></path><defs><marker id="arrowhead43" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g><g class="edgePath" style="opacity: 1;"><path class="path" d="M1226.62890625,764.375L1226.62890625,818.90625L1226.62890625,873.4375" marker-end="url(#arrowhead44)" style="fill:none"></path><defs><marker id="arrowhead44" viewBox="0 0 10 10" refX="9" refY="5" markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" class="arrowheadPath" style="stroke-width: 1; stroke-dasharray: 1, 0;"></path></marker></defs></g></g><g class="edgeLabels"><g class="edgeLabel" style="opacity: 1;" transform=""><g transform="translate(0,0)" class="label"><foreignObject width="0" height="0"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel"></span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(682.421875,271.40625)"><g transform="translate(-239.671875,-29.53125)" class="label"><foreignObject width="479.35546875" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">found matching access rule</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(221.375,271.40625)"><g transform="translate(-201.375,-29.53125)" class="label"><foreignObject width="402.7587890625" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">did not find access rule</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(967.109375,453.90625)"><g transform="translate(-267.03125,-29.53125)" class="label"><foreignObject width="534.0673828125" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">credentials in request are valid</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(397.734375,453.90625)"><g transform="translate(-282.34375,-29.53125)" class="label"><foreignObject width="564.697265625" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">credentials in request are invalid</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(707.58984375,636.40625)"><g transform="translate(-295.484375,-29.53125)" class="label"><foreignObject width="590.9765625" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">request does not have permission</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(1226.62890625,636.40625)"><g transform="translate(-203.5546875,-29.53125)" class="label"><foreignObject width="407.109375" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">request has permission</span></div></foreignObject></g></g><g class="edgeLabel" style="opacity: 1;" transform="translate(1226.62890625,818.90625)"><g transform="translate(-192.5859375,-29.53125)" class="label"><foreignObject width="385.1806640625" height="59.0625"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;"><span class="edgeLabel">transform http request</span></div></foreignObject></g></g></g><g class="nodes"><g class="node" style="opacity: 1;" id="401" transform="translate(397.734375,545.15625)"><rect rx="5" ry="5" x="-134.078125" y="-36.71875" width="268.15625" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-124.078125,-26.71875)"><foreignObject width="248.1591796875" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 401</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="403" transform="translate(707.58984375,727.65625)"><rect rx="5" ry="5" x="-134.078125" y="-36.71875" width="268.15625" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-124.078125,-26.71875)"><foreignObject width="248.1591796875" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 403</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="404" transform="translate(221.375,362.65625)"><rect rx="5" ry="5" x="-134.078125" y="-36.71875" width="268.15625" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-124.078125,-26.71875)"><foreignObject width="248.1591796875" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Error 404</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="r" transform="translate(451.8984375,56.71875)"><rect rx="5" ry="5" x="-123.5546875" y="-36.71875" width="247.109375" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-113.5546875,-26.71875)"><foreignObject width="227.109375" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">HTTP Request</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="arm" transform="translate(451.8984375,180.15625)"><rect rx="5" ry="5" x="-176.0859375" y="-36.71875" width="352.171875" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-166.0859375,-26.71875)"><foreignObject width="332.1826171875" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Access Rule Matcher</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="an" transform="translate(682.421875,362.65625)"><rect rx="5" ry="5" x="-123.265625" y="-36.71875" width="246.53125" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-113.265625,-26.71875)"><foreignObject width="226.5380859375" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Authenticator</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="az" transform="translate(967.109375,545.15625)"><rect rx="5" ry="5" x="-95.890625" y="-36.71875" width="191.78125" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-85.890625,-26.71875)"><foreignObject width="171.7822265625" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Authorizer</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="mt" transform="translate(1226.62890625,727.65625)"><rect rx="5" ry="5" x="-73.984375" y="-36.71875" width="147.96875" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-63.984375,-26.71875)"><foreignObject width="127.96875" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Mutator</div></foreignObject></g></g></g><g class="node" style="opacity: 1;" id="res" transform="translate(1226.62890625,910.15625)"><rect rx="5" ry="5" x="-196.0859375" y="-36.71875" width="392.171875" height="73.4375"></rect><g class="label" transform="translate(0,0)"><g transform="translate(-186.0859375,-26.71875)"><foreignObject width="372.1728515625" height="53.4375"><div xmlns="http://www.w3.org/1999/xhtml" style="display: inline-block; white-space: nowrap;">Forward HTTP Request</div></foreignObject></g></g></g></g></g></g></svg>


### PR DESCRIPTION
The SVG looks broken on https://www.ory.sh/docs/oathkeeper/#decision-engine. Hopefully, this fresh export without any changes fixes it? Is there a staging server for documentation to test this out?