### PR TITLE
oathkeeper: update authenticators documentation

### DIFF
--- a/docs/oathkeeper/pipeline/authn.md
+++ b/docs/oathkeeper/pipeline/authn.md
@@ -407,7 +407,8 @@ fails, the credentials are considered invalid.
 ## `oauth2_introspection`
 
 The `oauth2_introspection` authenticator handles requests that have an Bearer
-Token in the Authorization Header (`Authorization: bearer <token>`). It then
+Token in the Authorization Header (`Authorization: bearer <token>`) or in a 
+different header or query parameter specified in configuration. It then
 uses OAuth 2.0 Token Introspection to check if the token is valid and if the
 token was granted the requested scope.
 
@@ -437,6 +438,15 @@ token was granted the requested scope.
     requested during the OAuth 2.0 Client Credentials Grant.
   - `scope` ([]string, optional) - The OAuth 2.0 Token Endpoint where the OAuth
     2.0 Client Credentials Grant will be performed.
+- `token_from` (object, optional) - The location of the bearer token. If not 
+  configured, the token will be received from a default location - 'Authorization' 
+  header. One and only one location (header or query) must be specified.
+  - `header` (string, required, one of) - The header (case insensitive) that must 
+  contain a Bearer token for request authentication. It can't be set along with 
+  query_parameter.
+  - `query_parameter` (string, required, one of) - The query parameter (case sensitive) 
+  that must contain a Bearer token for request authentication. It can't be set along 
+  with header.
 
 ```yaml
 # Global configuration file oathkeeper.yml
@@ -458,6 +468,10 @@ authenticators:
         scope:
           - introspect
         token_url: https://my-website.com/oauth2/token
+      token_from:
+        header: Custom-Authorization-Header
+        # or
+        # query_parameter: auth-token
 ```
 
 ```yaml
@@ -480,6 +494,10 @@ authenticators:
         scope:
           - introspect
         token_url: https://my-website.com/oauth2/token
+      token_from:
+        query_parameter: auth-token
+        # or
+        # header: Custom-Authorization-Header
 ```
 
 ### Access Rule Example
@@ -552,7 +570,8 @@ from the `username` field.
 ## `jwt`
 
 The `jwt` authenticator handles requests that have an Bearer Token in the
-Authorization Header (`Authorization: bearer <token>`). It assumes that the
+Authorization Header (`Authorization: bearer <token>`) or in a different 
+header or query parameter specified in configuration. It assumes that the
 token is a JSON Web Token and tries to verify the signature of it.
 
 ### Configuration
@@ -575,6 +594,15 @@ token is a JSON Web Token and tries to verify the signature of it.
 - Value `required_scope` ([]string) validates the scope of the JWT. It will
   checks for claims `scp`, `scope`, `scopes` in the JWT when validating the
   scope as that claim is not standardized.
+- `token_from` (object, optional) - The location of the bearer token. If not 
+  configured, the token will be received from a default location - 'Authorization' 
+  header. One and only one location (header or query) must be specified.
+  - `header` (string, required, one of) - The header (case insensitive) that must 
+  contain a Bearer token for request authentication. It can't be set along with 
+  query_parameter.
+  - `query_parameter` (string, required, one of) - The query parameter (case sensitive) 
+  that must contain a Bearer token for request authentication. It can't be set along 
+  with header.
 
 ```yaml
 # Global configuration file oathkeeper.yml
@@ -598,6 +626,10 @@ authenticators:
       trusted_issuers: https://my-issuer.com/
       allowed_algorithms:
         - RS256
+      token_from:
+        header: Custom-Authorization-Header
+        # or
+        # query_parameter: auth-token
 ```
 
 ```yaml
@@ -622,6 +654,10 @@ authenticators:
       trusted_issuers: https://my-issuer.com/
       allowed_algorithms:
         - RS256
+      token_from:
+        query_parameter: auth-token
+        # or
+        # header: Custom-Authorization-Header
 ```
 
 #### Validation example


### PR DESCRIPTION
Changes proposed in this PR:
* update oauth2_introspection and jwt authenticators documentation with information about setting alternative token location

related PR in Oathkeeper: https://github.com/ory/oathkeeper/pull/271
related Issue: https://github.com/ory/oathkeeper/issues/257