### PR TITLE
Remove Authentication Note (Token Introspection)

### DIFF
--- a/docs/hydra/sdk/api.md
+++ b/docs/hydra/sdk/api.md
@@ -8037,10 +8037,6 @@ token was not granted one of the scopes, the result of active will be false.
 }
 ```
 
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-basic, oauth2
-</aside>
 
 #### Code samples
 


### PR DESCRIPTION
The Token Introspection Endpoint is only available to admins
and therefore should not require any authentication.
See: https://github.com/ory/hydra/issues/1520