### PR TITLE
Remove unnecessary paragraph in Hydra API docs

### DIFF
--- a/docs/hydra/sdk/api.md
+++ b/docs/hydra/sdk/api.md
@@ -8199,9 +8199,6 @@ versioning.
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health
-status will never refer to the cluster state, only to a single instance.
-
 #### Responses
 
 <a id="get-service-version-responses"></a>


### PR DESCRIPTION
The removed paragraph makes sense in the `/health/alive` and `health/ready` endpoints documentation but feels misplaced for documenting the `/version` endpoint.