### PR TITLE
Clarify Token Instrospection endpoint

### DIFF
--- a/docs/hydra/oauth2.md
+++ b/docs/hydra/oauth2.md
@@ -894,6 +894,10 @@ determine meta-information about this token. OAuth 2.0 deployments can use this
 method to convey information about the authorization context of the token from
 the authorization server to the protected resource.
 
+The usage of an access token or client credentials is required to access the
+endpoint. ORY Hydra will however accept any valid token or valid credentials as
+there is no built-in access control.
+
 You can find more details on this endpoint in the
 [ORY Hydra API Docs](https://www.ory.sh/docs/). You can also use the CLI command
 `hydra token introspect <token>`.

--- a/docs/hydra/production.md
+++ b/docs/hydra/production.md
@@ -90,6 +90,12 @@ endpoints include:
 None of the administrative endpoints have any built-in access control. You can
 do simple `curl` or Postman requests to talk to them.
 
+The Token Introspection endpoint requires authentication. But since there is no
+access control, any valid authentication enables the endpoint to be used. If
+you need to access this endpoint in production, you should configure your API
+Gateway or Application Proxy to restrict which clients have access to the
+endpoint.
+
 We generally advise to run ORY Hydra with `hydra serve all` which listens on
 both ports in one process. Please be aware that the `memory` backend will not
 work in this mode.


### PR DESCRIPTION
Clarify the situation of the Token Introspection endpoint requiring authentication but having no access-control.

[Related forum discussion](https://community.ory.sh/t/token-introspection-not-working/1330)