### PR TITLE
oathkeeper: add missing "token_from->cookie" documentation for jwt authenticator (#243)

### DIFF
--- a/docs/oathkeeper/pipeline/authn.md
+++ b/docs/oathkeeper/pipeline/authn.md
@@ -628,14 +628,17 @@ JSON Web Token and tries to verify the signature of it.
   scope as that claim is not standardized.
 - `token_from` (object, optional) - The location of the bearer token. If not
   configured, the token will be received from a default location -
-  'Authorization' header. One and only one location (header or query) must be
+  'Authorization' header. One and only one location (header, query, or cookie) must be
   specified.
   - `header` (string, required, one of) - The header (case insensitive) that
     must contain a Bearer token for request authentication. It can't be set
-    along with query_parameter.
+    along with `query_parameter` or `cookie`.
   - `query_parameter` (string, required, one of) - The query parameter (case
     sensitive) that must contain a Bearer token for request authentication. It
-    can't be set along with header.
+    can't be set along with `header` or `cookie`.
+  - `cookie` (string, required, one of) - The cookie (case sensitive) that must
+    contain a Bearer token for request authentication. It can't be set along
+    with `header` or `query_parameter`
 
 ```yaml
 # Global configuration file oathkeeper.yml
@@ -664,6 +667,8 @@ authenticators:
         header: Custom-Authorization-Header
         # or
         # query_parameter: auth-token
+        # or
+        # cookie: auth-token
 ```
 
 ```yaml
@@ -693,6 +698,8 @@ authenticators:
         query_parameter: auth-token
         # or
         # header: Custom-Authorization-Header
+        # or
+        # cookie: auth-token
 ```
 
 #### Validation example

--- a/schemas/oathkeeper.config.schema.json
+++ b/schemas/oathkeeper.config.schema.json
@@ -375,7 +375,7 @@
         },
         "token_from": {
           "title": "Token From",
-          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query or cookie) must be specified.",
           "oneOf": [
             {
               "type": "null"
@@ -387,7 +387,7 @@
                 "header": {
                   "title": "Header",
                   "type": "string",
-                  "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter."
+                  "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter or cookie."
                 }
               }
             },
@@ -398,10 +398,22 @@
                 "query_parameter": {
                   "title": "Query Parameter",
                   "type": "string",
-                  "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header."
+                  "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header or cookie."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cookie": {
+                  "title": "Cookie",
+                  "type": "string",
+                  "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."
                 }
               }
             }
+
           ]
         }
       },
@@ -556,7 +568,7 @@
         },
         "token_from": {
           "title": "Token From",
-          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query or cookie) must be specified.",
           "oneOf": [
             {
               "type": "null"

--- a/schemas/oathkeeper.config.schema.json
+++ b/schemas/oathkeeper.config.schema.json
@@ -375,7 +375,7 @@
         },
         "token_from": {
           "title": "Token From",
-          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query or cookie) must be specified.",
+          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
           "oneOf": [
             {
               "type": "null"
@@ -387,7 +387,7 @@
                 "header": {
                   "title": "Header",
                   "type": "string",
-                  "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter or cookie."
+                  "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter."
                 }
               }
             },
@@ -398,22 +398,10 @@
                 "query_parameter": {
                   "title": "Query Parameter",
                   "type": "string",
-                  "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header or cookie."
-                }
-              }
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cookie": {
-                  "title": "Cookie",
-                  "type": "string",
-                  "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."
+                  "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header."
                 }
               }
             }
-
           ]
         }
       },
@@ -568,7 +556,7 @@
         },
         "token_from": {
           "title": "Token From",
-          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query or cookie) must be specified.",
+          "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
           "oneOf": [
             {
               "type": "null"


### PR DESCRIPTION
oathkeeper: add missing "token_from->cookie" documentation for jwt authenticator (#243)

Signed-off-by: Grigoriev, Nikolai <ngrigoriev@gmail.com>