### PR TITLE
Update production.md to add a logout endpoint.

### DIFF
--- a/docs/hydra/production.md
+++ b/docs/hydra/production.md
@@ -72,6 +72,7 @@ handles requests to:
 - `/oauth2/revoke`
 - `/oauth2/fallbacks/consent`
 - `/oauth2/fallbacks/error`
+- `/oauth2/sessions/logout`
 - `/userinfo`
 
 The administrative port should not be exposed to public internet traffic. If you


### PR DESCRIPTION
I try to make a production environment and find that I cannot access a logout endpoint from public internet.
Should I not allow to access this logout endpoint from the internet?