### PR TITLE
fix: Spelling error for Kratos

### DIFF
--- a/docs/kratos/quickstart.md
+++ b/docs/kratos/quickstart.md
@@ -50,7 +50,7 @@ and of course:
 ## Setup
 
 As you might already know, ORY Kratos is API-only. It does not have a UI or HTML
-Templating Engine. We will implement the all the user-facing UIs (dashboard,
+Templating Engine. We will implement all the user-facing UIs (dashboard,
 login, registration, ...) in our NodeJS SecureApp!
 
 To ensure that no one can access the dashboard without prior authentication


### PR DESCRIPTION
Fixed spelling error in the Quickstart for Kratos, one too many "the".