### PR TITLE
docs: sqa.md: minor content, markdown tweaks

### DIFF
--- a/docs/ecosystem/sqa.md
+++ b/docs/ecosystem/sqa.md
@@ -33,10 +33,9 @@ The data processing pipeline has the following steps:
 5. The downloaded data is extracted, filtered, processed, and analyzed. The
    output is a CSV report which we analyze using Open Office.
 
-We built this pipeline the data with the following goals:
+We built this pipeline with the following goals in mind:
 
-1. Be able to say how many production deployments exist.
-
+- Be able to say how many production deployments exist.
 - Understand which features are used and how.
 - Understand how much throughput deployments handle.
 - Evaluate how frequently specific features are used.
@@ -118,9 +117,9 @@ We collect the following system metrics:
 
 ### Request telemetry
 
-The ip addresses of both host and client are anonymized to `0.0.0.0`. Any
-identifiable information in the URL path and query is hashed with sha256 using a
-randomly assigned uuid v4 salt:
+The IP addresses of both host and client are anonymized to `0.0.0.0`. Any
+identifiable information in the URL path and query is hashed with SHA-256 using a
+randomly assigned UUID v4 salt:
 
 - `/clients/foo` with salt `ABCDEFGH` becomes `/clients/sha256("foo|ABCDEFGH")`:
   `/clients/0301424a80469ad03a208de925563a97ec6ab2f9dc7a2ad71b2ded85a7f7a7af`


### PR DESCRIPTION
- markdown: one instance of normalizing list syntax (first item in list was
  numbered, but rest of list items were unordered)

- prose: use "SHA-256" everywhere (rather than sometimes saying "sha256")

- prose: change one instance of "ip addresses" to "IP addresses" (for
  consistency with usage elsewhere in the article)

- prose: use "UUID" rather than "uuid" (for consistency -- most acronyms in
  article are in all caps)

- prose: restate: "We built this pipeline the data with the following goals:"
              as: "We built this pipeline with the following goals in mind:"