### PR TITLE
docs: add general contributing to sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -11,5 +11,6 @@
     "ecosystem/community",
     "ecosystem/roadmap",
     "ecosystem/sqa"
+    "ecosystem/contributing"
   ]
 }


### PR DESCRIPTION
Added the ecosystem or github inner workings documentation to the sidebar, it was just sitting there in the docs, all forgotten...