### PR TITLE
Issue 2267 update doc on limit param upper bound

### DIFF
--- a/docs/docs/ecosystem/api-design.md
+++ b/docs/docs/ecosystem/api-design.md
@@ -22,7 +22,7 @@ pages (where applicable):
 
 Pages are created based on the values of `limit` and `offset` provided in the
 querystring, where `limit` is the page size, and `offset` is the current item.
-The `limit` parameter always has an API specific upper bound to prevent DoS 
+The `limit` parameter always has an API specific upper bound to prevent DoS. 
 
 In most scenarios, the `offset` should be a multiple of the `limit`.
 

--- a/docs/docs/ecosystem/api-design.md
+++ b/docs/docs/ecosystem/api-design.md
@@ -22,6 +22,7 @@ pages (where applicable):
 
 Pages are created based on the values of `limit` and `offset` provided in the
 querystring, where `limit` is the page size, and `offset` is the current item.
+The `limit` parameter always has an API specific upper bound to prevent DoS 
 
 In most scenarios, the `offset` should be a multiple of the `limit`.
 


### PR DESCRIPTION
Issue `#2267`: Document that there is an upper bound on `limit` parameter to prevent DoS