### PR TITLE
docs: add project

### DIFF
--- a/docs/docs/ecosystem/community.md
+++ b/docs/docs/ecosystem/community.md
@@ -27,9 +27,9 @@ This is a list of those.
 
 - Open source software
 
-  - [Ory Kratos Python Frontend](https://github.com/k9ert/Ory-tinker/)
   - [Ory Kratos "hydra-integration" branch](https://github.com/Ory/kratos-selfservice-ui-node/tree/hydra-integration-2021)
   - [WIP: Ory Hydra/ Ory Oathkeeper Zero Trust Reference "Hello World App"](https://github.com/JasonCubic/oathkeeper_hydra_reverse_proxy)
+  - [Ory Hydra Terraform provider](https://github.com/svrakitin/terraform-provider-hydra)
   - [Ory Hydra PoC for OAuth2/OpenID Connect provider](https://git.dittberner.info/jan/hydra_oidc_poc)
   - [Ory Hydra Identity Provider for over LDAP](https://github.com/i-core/werther)
   - [Ory Hydra Two-factor authentication login provider](https://github.com/epandurski/hydra_login2f)


### PR DESCRIPTION
Added a community project and removed @k9ert project (for now).

@aeneasr do you have any input on how we could integrate this page into ory/works? 

We could just link it, but imo would be nice to have all that info directly in the ory/works readme too.. 

I could append it, like we do with ADOPTERS.md in the other readmes, what do you think of that approach?