### PR TITLE
fix: typo

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -65,7 +65,7 @@ valuable insights in form of dashboards, and customization.
 ### Managed UI
 
 The Managed UI implements screens such as login, registration, account recovery,
-account setting, account verification. This allows for fast adoption of Ory.
+account setting, and account verification. This allows for fast adoption of Ory.
 
 Contrary to other vendors, Ory allows you to implement your own (login,
 registration, ...) UI by offering simple, headless APIs.
@@ -110,12 +110,12 @@ vision for Ory Cloud is to incorporate and advance the open source ecosystem and
 add additional services which are not possible to open source (e.g. Analytics,
 SLAs, SRE, Low-Latency).
 
-Ory Cloud and our open source software is interlinked. While we have made some
+Ory Cloud and our open source software are interlinked. While we have made some
 modifications to the open source to make it work better in our multi-tenant
 environment and operational (SRE) model, we are using the same code base, APIs,
 features, and configurations for the Ory Cloud.
 
 In the future, we will increase our open source footprint, make the projects
 easier to modify, use, access, and distribute. The only impact Ory Cloud will
-have, is that development is accelerated as we are able to spend more resources
+have is that it will accelerate development and enable us to spend more resources
 on the open source!


### PR DESCRIPTION
Added "and" at end of list:  "account recovery,
account setting, and account verification."
Verb-noun agreement: "Ory Cloud and our open source software is interlinked" > "Ory Cloud and our open source software are interlinked"
Re-write for flow: "The only impact Ory Cloud will have, is that development is accelerated as we are able to spend more resources on the open source!" > "The only impact Ory Cloud will have is that it will accelerate development and enable us to spend more resources
on the open source!"