### PR TITLE
fix: proxy command

### DIFF
--- a/docs/docs/start-building/server-side-web-app.mdx
+++ b/docs/docs/start-building/server-side-web-app.mdx
@@ -80,9 +80,7 @@ Next, run the Ory Proxy with
   protecting.
 
 ```shell
-Ory Proxy local \
-  --port 4000 \
-  http://localhost:8000/
+ory proxy local	--port 4000	http://localhost:8000/
 ```
 
 Your operating system will prompt you for your administrative password. The Ory


### PR DESCRIPTION
The command doesn't work with capitalized P and I also get `Error: accepts 1 arg(s), received 3`
for `ory proxy local \  --port 4000 \  http://localhost:8000/`

It works with `ory proxy local --port 4000 http://localhost:8000/`
