### PR TITLE
fix: putting proper list for native and mobile app in native-mobile-app.mdx

### DIFF
--- a/docs/docs/start-building/native-mobile-app.mdx
+++ b/docs/docs/start-building/native-mobile-app.mdx
@@ -4,10 +4,26 @@ sidebar_label: Native & Mobile Apps
 title: Build a Native / Mobile App with Ory
 ---
 
-Ory supports server-side web apps natively. To get building, pick the technology
+Ory supports native and mobile apps natively. To get building, pick the technology
 you are using:
 
-- [ReactJS](./other-languages.mdx)
-- [NextJS](./other-languages.mdx)
-- [Gatsby](./other-languages.mdx)
-- [AngularJS](./other-languages.mdx)
+- [React Native](#react-native)
+- [Android](./other-languages.mdx)
+- [iOS Swift](./other-languages.mdx)
+- [Cordova](./other-languages.mdx)
+- [smartTV](./other-languages.mdx)
+- [Ionic](./other-languages.mdx)
+- [Windows](./other-languages.mdx)
+
+## React Native
+
+While a guide for React Native is not yet available for Ory Cloud, you can check
+out the React Native guide and code example for Open Source Ory Kratos, which is
+powering Ory Cloud's identity features.
+
+- [Add Authentication to your React Native App](https://www.ory.sh/login-react-native-authentication-example-api/)
+- React Native integration on
+  [GitHub](https://github.com/ory/kratos-selfservice-ui-react-native)
+
+The guide and examples are already using the Ory Cloud playground object. If you
+have your own object, all you need to do is replace the project slug!


### PR DESCRIPTION
The current list of technologies are used for single page apps