### PR TITLE
fix: cloud proxy docs

### DIFF
--- a/docs/docs/concepts/terminology.mdx
+++ b/docs/docs/concepts/terminology.mdx
@@ -9,6 +9,55 @@ An overview of the terminology used in the Ory Cloud documentation.
 If you think a term is missing here, please
 [let us know](https://github.com/ory/docs/issues/new).
 
+## Ory Cloud Terms
+
+#### Ory Cloud Project
+
+A single deployment of Ory Cloud. Each project runs its own copy of the Ory
+services. Learn more about [Ory Cloud Projects](./project.mdx).
+
+#### Ory Cloud Project Settings
+
+The configuration for each individual Ory Project Cloud can be changed in the
+Ory Project Settings.
+
+#### Ory Cloud Console
+
+The graphical user interface that can be used to administer and manage Ory Cloud
+Projects. You can it at [https://console.ory.sh/](https://console.ory.sh/).
+
+#### Ory SDK URL
+
+The environmental variable `ORY_SDK_URL` specifies where the Ory instance is
+available. It can be found in the "API & Services" section of your Ory Cloud
+Console.
+
+#### Identity Schema
+
+The JSON Schema that defines an identity in an Ory Cloud Project. Learn more
+about [Identity Schemas](./identity.mdx).
+
+#### Ory Login Session
+
+A cookie or token that is stored in the users' Browser or API Client. It
+represents a successful Login Flow and lets the user access the authenticated
+identity.
+
+#### Ory Project Slug
+
+A generic identifier for each Ory Cloud project. It has the format
+`adjective-name-randomstring` e.g.: `suspicious-curran-y23rz7k2t`.
+
+#### Ory Project Public API
+
+The Ory Kratos endpoint for accessing your project's public API, it is composed
+like so: `https://$ORY_PROJECT_SLUG/api/kratos/public`.
+
+#### Ory Project Admin API
+
+The Ory Kratos endpoint for accessing your project's administrative API, it is
+composed like so: `https://$ORY_PROJECT_SLUG/api/kratos/admin`.
+
 ## Basics
 
 #### End-User
@@ -74,41 +123,3 @@ certain identity) at your application.
 
 The path that a user has to take in order to recover access to their account,
 e.g. through a verified email or other means.
-
-## Ory Cloud specific Terms
-
-#### Ory Cloud Project
-
-A single deployment of Ory Cloud. Each project runs its own copy of the Ory
-services. Learn more about [Ory Cloud Projects](./project.mdx).
-
-#### Ory Cloud Project Settings
-
-The configuration for each individual Ory Project Cloud can be changed in the
-Ory Project Settings.
-
-#### Identity Schema
-
-The JSON Schema that defines an identity in an Ory Cloud Project. Learn more
-about [Identity Schemas](./identity.mdx).
-
-#### Ory Login Session
-
-A cookie or token that is stored in the users' Browser or API Client. It
-represents a successful Login Flow and lets the user access the authenticated
-identity.
-
-#### Ory Project Slug
-
-The generic URL that is generated when a project is created, e.g.
-`https://suspicious-curran-y23rz7k2t.projects.oryapis.com`.
-
-#### Ory Project Public API
-
-The Ory Kratos endpoint for accessing your project's public API, it is composed
-like so: `https://$ORY_PROJECT_SLUG/api/kratos/public`.
-
-#### Ory Project Admin API
-
-The Ory Kratos endpoint for accessing your project's administrative API, it is
-composed like so: `https://$ORY_PROJECT_SLUG/api/kratos/admin`.

--- a/docs/docs/guides/proxy.mdx
+++ b/docs/docs/guides/proxy.mdx
@@ -1,13 +1,13 @@
 ---
 id: proxy
-title: Using the Ory Proxy
+title: Using Ory Proxy
 ---
 
-The Ory Proxy is a powerful tool which authenticates users, converts session
+Ory Proxy is a powerful tool which authenticates users, converts session
 into a JSON Web Token, and ensures that cookies and URLs are properly
 configured.
 
-Using Ory Cloud without the Ory Proxy is currently not encouraged, unless you
+Using Ory Cloud without Ory Proxy is currently not encouraged, unless you
 are writing a mobile application or are only interacting with Ory Cloud's Admin
 APIs.
 
@@ -17,17 +17,17 @@ development machine or server.
 
 ## Concepts
 
-Before heading into the concrete examples, let's look at some of the Ory Proxy's
+Before heading into the concrete examples, let's look at some of Ory Proxy's
 concepts.
 
 ### URL Structure
 
-The Ory Proxy mirrors Ory Cloud's APIs and UIs under the `/.ory` path. If you
+Ory Proxy mirrors Ory Cloud's APIs and UIs under the `/.ory` path. If you
 were to call, for example, the URL
 `https://<your-project-slug>.projects.oryapis.com/ui/login`, the equivalent
 proxied URL would be `https://<proxy-host>/.ory/ui/login`.
 
-The Ory Proxy has a few shorthand URLs which you can use to initiate
+Ory Proxy has a few shorthand URLs which you can use to initiate
 self-service flows:
 
 - `/.ory/self-service/login/browser` initiates the self-service login flow.
@@ -63,8 +63,8 @@ possible.
 
 ### Zero Trust
 
-The Ory Proxy translates any known Ory credentials (e.g. Ory Session Token or
-Ory Session Cookie) to a JSON Web Token. Assuming the user calls the Ory Proxy
+Ory Proxy translates any known Ory credentials (e.g. Ory Session Token or
+Ory Session Cookie) to a JSON Web Token. Assuming the user calls Ory Proxy
 with a valid Ory Session Cookie
 
 ```
@@ -75,9 +75,9 @@ User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (
 ...
 ```
 
-the Ory Proxy resolves that session and converts it to a JSON Web Token which is
+Ory Proxy resolves that session and converts it to a JSON Web Token which is
 included in the HTTP Request's `Authorization` Header which is made to the
-"upstream" (the URL which the Ory Proxy is protecting). The session cookie will
+"upstream" (the URL which Ory Proxy is protecting). The session cookie will
 still be included in the request, in case that you need it to generate a logout
 URL for example.
 
@@ -90,7 +90,7 @@ User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (
 ...
 ```
 
-We strongly encourage you to validate the JSON Web Token using the Ory Proxy's
+We strongly encourage you to validate the JSON Web Token using Ory Proxy's
 public key. The public key is available at `/.ory/proxy/jwks.json`:
 
 ```
@@ -175,8 +175,8 @@ Cookie:
 
 Before you start set the environment variable [`ORY_SDK_URL`](../concepts/terminology#ory-sdk-url). It can be found in the "API & Services" section of your Ory Cloud Console.
 
-The Ory Proxy works great on local machines (`localhost`). Assuming you are
-running, for example, a NodeJS app on port 3000, you would point the Ory Proxy
+Ory Proxy works great on local machines (`localhost`). Assuming you are
+running, for example, a NodeJS app on port 3000, you would point Ory Proxy
 to that URL:
 
 ```
@@ -189,11 +189,11 @@ For more information on other CLI flags run `ory help proxy` or head over to the
 
 ## Production
 
-The Ory Proxy is also capable of protecting remote and production environments.
+Ory Proxy is also capable of protecting remote and production environments.
 Alternatively you can also use
 [DNS CNAME](../start-building/deploy-auth-production.mdx). The only difference
 to running the proxy locally, is that you append the root URL where your app
-(via the Ory Proxy) is exposed at:
+(via Ory Proxy) is exposed at:
 
 ```
 export ORY_SDK_URL=https://<project>.projects.oryapis.com/
@@ -206,7 +206,7 @@ the browser, run `ory help proxy` or head over to the
 
 ### Running on a VM
 
-If you are deploying on a VM, Virtual or Dedicated Server using the Ory Proxy is
+If you are deploying on a VM, Virtual or Dedicated Server using Ory Proxy is
 easy! Just run your application server and the proxy in parallel. Assuming you
 are using NodeJS to run your server on port 3000, and are exposing web traffic
 at port 8080, use:
@@ -225,7 +225,7 @@ node your-entrypoint.js
 
 ### Running in Docker
 
-One option is to add both the Ory Proxy and your service to a Docker container.
+One option is to add both Ory Proxy and your service to a Docker container.
 
 :::warning
 
@@ -235,11 +235,11 @@ crashes, Docker will not be notified. To get a more stable system in place,
 please follow
 [Run multiple services in a container](https://docs.docker.com/config/containers/multi-service_container/).
 
-For simplicity we have chosen to run the Ory Proxy as a background task here!
+For simplicity we have chosen to run Ory Proxy as a background task here!
 
 :::
 
-To run the Ory Proxy alongside your application, create a file called
+To run Ory Proxy alongside your application, create a file called
 `entrypoint.sh` with a content along the lines of:
 
 ```shell
@@ -271,12 +271,12 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 ### Kubernetes
 
-Adding a Helm Chart for the Ory Proxy is on the roadmap, which would allow
-running the Ory Proxy either as a Service, Ingress, or Side Car!
+Adding a Helm Chart for Ory Proxy is on the roadmap, which would allow
+running Ory Proxy either as a Service, Ingress, or Side Car!
 
 ## Troubleshooting
 
-If you run get an error while working with the Ory Proxy or Ory CLI , make sure
+If you run get an error while working with Ory Proxy or Ory CLI , make sure
 you are on the latest version.
 
 - For

--- a/docs/docs/guides/proxy.mdx
+++ b/docs/docs/guides/proxy.mdx
@@ -170,7 +170,7 @@ Cookie:
 }
 ```
 
-## Local Development
+## Ory Proxy for Local Development
 
 Before you start set the environment variable
 [`ORY_SDK_URL`](../concepts/terminology#ory-sdk-url). It can be found in the
@@ -187,7 +187,7 @@ ory proxy http://localhost:3000
 For more information on other CLI flags run `ory help proxy` or head over to the
 [Ory Proxy Local Reference](../cli/ory-proxy.md).
 
-## Production
+## Ory Proxy for Production
 
 Ory Proxy is also capable of protecting remote and production environments.
 Alternatively you can also use

--- a/docs/docs/guides/proxy.mdx
+++ b/docs/docs/guides/proxy.mdx
@@ -3,12 +3,11 @@ id: proxy
 title: Using Ory Proxy
 ---
 
-Ory Proxy is a powerful tool which authenticates users, converts session
-into a JSON Web Token, and ensures that cookies and URLs are properly
-configured.
+Ory Proxy is a powerful tool which authenticates users, converts session into a
+JSON Web Token, and ensures that cookies and URLs are properly configured.
 
-Using Ory Cloud without Ory Proxy is currently not encouraged, unless you
-are writing a mobile application or are only interacting with Ory Cloud's Admin
+Using Ory Cloud without Ory Proxy is currently not encouraged, unless you are
+writing a mobile application or are only interacting with Ory Cloud's Admin
 APIs.
 
 If you haven't already, please
@@ -22,13 +21,13 @@ concepts.
 
 ### URL Structure
 
-Ory Proxy mirrors Ory Cloud's APIs and UIs under the `/.ory` path. If you
-were to call, for example, the URL
+Ory Proxy mirrors Ory Cloud's APIs and UIs under the `/.ory` path. If you were
+to call, for example, the URL
 `https://<your-project-slug>.projects.oryapis.com/ui/login`, the equivalent
 proxied URL would be `https://<proxy-host>/.ory/ui/login`.
 
-Ory Proxy has a few shorthand URLs which you can use to initiate
-self-service flows:
+Ory Proxy has a few shorthand URLs which you can use to initiate self-service
+flows:
 
 - `/.ory/self-service/login/browser` initiates the self-service login flow.
 - `/.ory/self-service/registration/browser` initiates the self-service
@@ -63,9 +62,9 @@ possible.
 
 ### Zero Trust
 
-Ory Proxy translates any known Ory credentials (e.g. Ory Session Token or
-Ory Session Cookie) to a JSON Web Token. Assuming the user calls Ory Proxy
-with a valid Ory Session Cookie
+Ory Proxy translates any known Ory credentials (e.g. Ory Session Token or Ory
+Session Cookie) to a JSON Web Token. Assuming the user calls Ory Proxy with a
+valid Ory Session Cookie
 
 ```
 GET /some-path
@@ -173,11 +172,12 @@ Cookie:
 
 ## Local Development
 
-Before you start set the environment variable [`ORY_SDK_URL`](../concepts/terminology#ory-sdk-url). It can be found in the "API & Services" section of your Ory Cloud Console.
+Before you start set the environment variable
+[`ORY_SDK_URL`](../concepts/terminology#ory-sdk-url). It can be found in the
+"API & Services" section of your Ory Cloud Console.
 
-Ory Proxy works great on local machines (`localhost`). Assuming you are
-running, for example, a NodeJS app on port 3000, you would point Ory Proxy
-to that URL:
+Ory Proxy works great on local machines (`localhost`). Assuming you are running,
+for example, a NodeJS app on port 3000, you would point Ory Proxy to that URL:
 
 ```
 export ORY_SDK_URL=https://<project>.projects.oryapis.com/
@@ -271,13 +271,13 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 ### Kubernetes
 
-Adding a Helm Chart for Ory Proxy is on the roadmap, which would allow
-running Ory Proxy either as a Service, Ingress, or Side Car!
+Adding a Helm Chart for Ory Proxy is on the roadmap, which would allow running
+Ory Proxy either as a Service, Ingress, or Side Car!
 
 ## Troubleshooting
 
-If you run get an error while working with Ory Proxy or Ory CLI , make sure
-you are on the latest version.
+If you run get an error while working with Ory Proxy or Ory CLI , make sure you
+are on the latest version.
 
 - For
   [brew (MacOs)](https://www.ory.sh/docs/start-building/ory-cli-install-use#install-on-macos)

--- a/docs/docs/guides/proxy.mdx
+++ b/docs/docs/guides/proxy.mdx
@@ -171,22 +171,23 @@ Cookie:
 }
 ```
 
-## Ory Proxy for Local Development
+## Local Development
+
+Before you start set the environment variable [`ORY_SDK_URL`](../concepts/terminology#ory-sdk-url). It can be found in the "API & Services" section of your Ory Cloud Console.
 
 The Ory Proxy works great on local machines (`localhost`). Assuming you are
 running, for example, a NodeJS app on port 3000, you would point the Ory Proxy
 to that URL:
 
 ```
-export ORY_ACCESS_TOKEN=<your personal access token here>
-ory proxy local http://localhost:3000
+export ORY_SDK_URL=https://<project>.projects.oryapis.com/
+ory proxy http://localhost:3000
 ```
 
-For other CLI flags which, for example, disable the auto-opening of the URL in
-the browser, run `ory help proxy` or head over to the
+For more information on other CLI flags run `ory help proxy` or head over to the
 [Ory Proxy Local Reference](../cli/ory-proxy.md).
 
-## Ory Proxy for Production
+## Production
 
 The Ory Proxy is also capable of protecting remote and production environments.
 Alternatively you can also use


### PR DESCRIPTION
closes https://github.com/ory-corp/cloud/issues/1684

- adds ORY_SDK_URL to terminology doc
- puts Ory specific terms at the top of said doc
- removes ory proxy local as the command is no longer working
- shortens headings from "Ory Proxy for Local Development" to "Local Development", looks cleaner, and should be clear from the heading that it concerns ory proxy. 


optional can be reverted:
- removes the articles, "The Ory Proxy" -> "Ory Proxy", which makes it sound like a proper product. if merged, will remove other articles as well. 

