### PR TITLE
chore: add consent banner support

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -188,6 +188,7 @@ module.exports = {
       }
     ],
     '@docusaurus/plugin-content-pages',
+    require.resolve('./src/plugins/analytics'),
     require.resolve('./src/plugins/docusaurus-plugin-matamo'),
     '@docusaurus/plugin-sitemap'
   ],

--- a/docs/src/plugins/analytics/analytics.js
+++ b/docs/src/plugins/analytics/analytics.js
@@ -12,18 +12,22 @@ export default (function () {
     return null
   }
 
+  const script = document.createElement('script')
+  script.onload = (evt) => console.info('/scripts.js loaded', evt)
+  script.src = '/scripts.js'
+  document.body.appendChild(script)
+  console.info('loading /scripts.js');
+  
   return {
-    onRouteUpdate({ location }) {
-      if (typeof window.gtag !== 'function') {
-        return
+    onRouteUpdate() {
+      console.info('onRouteUpdate', typeof window.initAnalytics);
+      if (
+        window
+        && typeof window.initAnalytics === 'function'
+        // && process.env.NODE_ENV === 'production'
+      ) {
+        window.initAnalytics()
       }
-
-      const pagePath = location
-        ? location.pathname + location.search + location.hash
-        : undefined
-      window.gtag('config', 'UA-71865250-1', {
-        page_path: pagePath
-      })
     }
   }
 })()


### PR DESCRIPTION
The goal of this PR is to ensure that the same analytics and consent banner are applied consistently across the website and the documentation by loading the `https:www.ory.sh/scripts.js` provided in https://github.com/ory/web (https://github.com/ory/web/pull/499).