### PR TITLE
fix: incorrect pat usage

### DIFF
--- a/docs/docs/start-building/server-side-web-app.mdx
+++ b/docs/docs/start-building/server-side-web-app.mdx
@@ -15,9 +15,8 @@ you are using:
 - [Other language / framework](./other-languages.mdx)
 
 Before you get started, please install the [Ory CLI](./ory-cli-install-use.mdx)
-on your system, and have a
-[running Ory Project](https://console.ory.sh/registration) and a
-[Personal Access Token](../guides/create-personal-access-token.mdx) ready.
+on your system and have a
+[running Ory Project](https://console.ory.sh/registration).
 
 For more information on the Ory Cloud SDK and Services and please see the
 [Services & APIs docs](../concepts/services-api.mdx).


### PR DESCRIPTION
The documentation on start-building describes the user should create a PAT token, leading them to be confused when it is not used anywhere in the guide.