### PR TITLE
docs: clarify which databases are supported

### DIFF
--- a/docs/docs/ecosystem/deployment.md
+++ b/docs/docs/ecosystem/deployment.md
@@ -28,11 +28,8 @@ to `memory`.
 
 ### SQL (persistent)
 
-All Ory projects support PostgreSQL and MySQL as first-class citizens.
-
-Ory Hydra additionally supports CockroachDB.
-
-Ory Kratos additionally supports SQLite.
+All Ory projects support PostgreSQL, MySQL, SQLite and CockroachDB as
+first-class citizens.
 
 ##### SQLite
 


### PR DESCRIPTION
Clarifies which databases are supported as this was causing some confusion. 

I was not sure if SQLite should be in the list as "first-class citizen"; 
should SQLite generally not be used in production, or just not for Ory Keto? 