### PR TITLE
fix: docs build in Kratos

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -35,7 +35,7 @@
           "concepts/self-service",
           "concepts/redirects",
           "concepts/session",
-          "concepts/email",
+          "concepts/emails",
           "ecosystem/api-design"
         ]
       },


### PR DESCRIPTION
Looks like this is breaking docs build for Kratos:

```
Error: Server responded to https://raw.githubusercontent.com/ory/docs/master/docs/docs/concepts/email.md with status code 404:
404: Not Found
```
Not 100% sure I get this right though.