### PR TITLE
feat: project invite cloud docs

### DIFF
--- a/docs/docs/concepts/project-membership.mdx
+++ b/docs/docs/concepts/project-membership.mdx
@@ -10,7 +10,50 @@ them an invite link via the entered email, notifying them of the project they
 are invited to as well as who has invited them (your email as the project
 owner).
 
-## Link Validity
+## Invite user
+
+### Without an Ory Cloud account
+
+Ory Cloud supports inviting user's without an Ory Cloud account, however, some
+conditions need to be met. Once the user follows the invite link, they will be
+required to register an account. The email entered upon registration has to
+match the email specified in the invite, if they do not match, the user will
+need to change their email through the settings flow or recreate an account. The
+invite also has to still be valid, this means the invite should not have expired
+or been used.
+
+### With Ory Cloud account
+
+The user can simply click on the link, sign in and accept the invite. Of course
+with the condition that the link is still valid.
+
+## Permissions
+
+Only project `owners` can invite more members to a project. Any invited member will
+automatically have the `developer` role assigned, thus preventing any new member from removing members or adding new ones.
+
+:::note
+
+It is currently not possible to elevate a member from `developer` to `owner`, but will become possible
+in the future.
+
+:::
+
+## Project Member Seats
+
+Each project, depending on the plan, has a set number of seats associated with
+it. The number of seats are used up by `pending` and `accepted` invites. Once
+the invite state changes to `expired`, `removed`, `declined` and `cancelled` the
+seat is freed up again. The reason for `pending` invites to take up seats are to
+prevent users from using up the seats on a first-come, first-served basis,
+leading to more invites sent than member slot availability.
+
+There are two ways to free up member seats:
+- Remove a member from the project will result in a `removed` status.
+- Cancel a `pending` invite will result in a `cancelled` status.
+
+
+## Invite State and Validity
 
 The invite can have many states, namely:
 
@@ -30,33 +73,20 @@ be either `accepted`, `declined`, `expired` or `cancelled`. Only the subject can
 
 [![](https://mermaid.ink/img/pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)](https://mermaid.live/edit/#pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)
 
+The link is only valid if it has no user account linked to it or has not expired.
+Once the link has been successfully linked to the user account, the invite will appear in the user's notification
+panel. Here the user can manage their invites.
+
+Once an invite has been completely removed by the project owner, the invite will also be removed for the invited user.
+
 :::note
 
 Invite Links expire after 6 hours and can only be used once.
 
 :::
 
-## Invite user
+:::warning
 
-### Without an Ory Cloud account
+Deleting an invite is irreversible
 
-Ory Cloud supports inviting user's without an Ory Cloud account, however, some
-conditions need to be met. Once the user follows the invite link, they will be
-required to register an account. The email entered upon registration has to
-match the email specified in the invite, if they do not match, the user will
-need to change their email through the settings flow or recreate an account. The
-invite also has to still be valid, this means the invite should not have expired
-or been used.
-
-### With Ory Cloud account
-
-The user can simply click on the link, sign in and accept the invite. Of course
-with the condition that the link is still valid.
-
-## Project Member Seats
-
-Each project, depending on the plan, has a set number of seats associated with
-it. The number of seats are used up by `pending` and `accepted` invites. Once
-the invite state changes to `expired`, `removed`, `declined` and `cancelled` the
-seat is freed up again. The reason for `pending` invites to take up seats are to
-prevent users from using up the seats on a first-come-first-serve basis.
+:::

--- a/docs/docs/concepts/project-membership.mdx
+++ b/docs/docs/concepts/project-membership.mdx
@@ -3,14 +3,12 @@ id: project-invite-membership
 title: Project Invites and Membership
 ---
 
-Project collaborators can be added by the project `owner` through the project invite flow.
-The invite flow requires the user's email address to be entered and does not depend on the user having an Ory Cloud account.
-Ory Cloud will send them an invite link via the entered email, notifying them of the project they are
-invited to as well as who has invited them (your email as the project owner).
-
-:::note
-Invite Links expire after 6 hours and can only be used once.
-:::
+Project collaborators can be added by the project `owner` through the project
+invite flow. The invite flow requires the user's email address to be entered and
+does not depend on the user having an Ory Cloud account. Ory Cloud will send
+them an invite link via the entered email, notifying them of the project they
+are invited to as well as who has invited them (your email as the project
+owner).
 
 ## Link Validity
 
@@ -23,29 +21,42 @@ The invite can have many states, namely:
 - removed
 - cancelled
 
-The state of the invite can only change in certain ways depending on the actions of the subject (invited user), the actor (project owner)
-and the system. In the below state diagram the invite state starts out at `pending` and then goes on to be either `accepted`, `declined`, `expired` or `cancelled`.
-Only the subject can `accept` and `decline` the invite, while the actor can `cancel`, `remove` and `delete` and invite. The system can `expire` an invite.
+The state of the invite can only change in certain ways depending on the actions
+of the subject (invited user), the actor (project owner) and the system. In the
+below state diagram the invite state starts out at `pending` and then goes on to
+be either `accepted`, `declined`, `expired` or `cancelled`. Only the subject can
+`accept` and `decline` the invite, while the actor can `cancel`, `remove` and
+`delete` an invite. The system can `expire` an invite.
 
 [![](https://mermaid.ink/img/pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)](https://mermaid.live/edit/#pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)
 
+:::note
 
-## Invite user without an Ory Cloud account
+Invite Links expire after 6 hours and can only be used once.
 
-Ory Cloud supports inviting user's without an Ory Cloud account, however, some conditions need to meet.
-Once the user follows the invite link, they will be required to register an account. The email entered upon registration
-has to match the email specified in the invite.
-The invite also has to still be valid, this means the invite should not have expired or already been used.
+:::
 
+## Invite user
 
-## Invite user with Ory Cloud account
+### Without an Ory Cloud account
 
-The user can simply click on the link, sign in and accept the invite. Of course with the condition that the link
-is still valid.
+Ory Cloud supports inviting user's without an Ory Cloud account, however, some
+conditions need to be met. Once the user follows the invite link, they will be
+required to register an account. The email entered upon registration has to
+match the email specified in the invite, if they do not match, the user will
+need to change their email through the settings flow or recreate an account. The
+invite also has to still be valid, this means the invite should not have expired
+or been used.
+
+### With Ory Cloud account
+
+The user can simply click on the link, sign in and accept the invite. Of course
+with the condition that the link is still valid.
 
 ## Project Member Seats
 
-Each project, depending on the plan, has a set number of seats associated with it. The number of seats are used up by
-`pending` and `accepted` invites. Once the invite state changes to `expired`, `removed`, `declined` and `cancelled` the seat
-is freed up again. The reason for `pending` invites to take up seats are to prevent users from using up the seats
-on a first-come-first-serve basis.
+Each project, depending on the plan, has a set number of seats associated with
+it. The number of seats are used up by `pending` and `accepted` invites. Once
+the invite state changes to `expired`, `removed`, `declined` and `cancelled` the
+seat is freed up again. The reason for `pending` invites to take up seats are to
+prevent users from using up the seats on a first-come-first-serve basis.

--- a/docs/docs/concepts/project-membership.mdx
+++ b/docs/docs/concepts/project-membership.mdx
@@ -1,0 +1,51 @@
+---
+id: project-invite-membership
+title: Project Invites and Membership
+---
+
+Project collaborators can be added by the project `owner` through the project invite flow.
+The invite flow requires the user's email address to be entered and does not depend on the user having an Ory Cloud account.
+Ory Cloud will send them an invite link via the entered email, notifying them of the project they are
+invited to as well as who has invited them (your email as the project owner).
+
+:::note
+Invite Links expire after 6 hours and can only be used once.
+:::
+
+## Link Validity
+
+The invite can have many states, namely:
+
+- pending
+- accepted
+- declined
+- expired
+- removed
+- cancelled
+
+The state of the invite can only change in certain ways depending on the actions of the subject (invited user), the actor (project owner)
+and the system. In the below state diagram the invite state starts out at `pending` and then goes on to be either `accepted`, `declined`, `expired` or `cancelled`.
+Only the subject can `accept` and `decline` the invite, while the actor can `cancel`, `remove` and `delete` and invite. The system can `expire` an invite.
+
+[![](https://mermaid.ink/img/pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)](https://mermaid.live/edit/#pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)
+
+
+## Invite user without an Ory Cloud account
+
+Ory Cloud supports inviting user's without an Ory Cloud account, however, some conditions need to meet.
+Once the user follows the invite link, they will be required to register an account. The email entered upon registration
+has to match the email specified in the invite.
+The invite also has to still be valid, this means the invite should not have expired or already been used.
+
+
+## Invite user with Ory Cloud account
+
+The user can simply click on the link, sign in and accept the invite. Of course with the condition that the link
+is still valid.
+
+## Project Member Seats
+
+Each project, depending on the plan, has a set number of seats associated with it. The number of seats are used up by
+`pending` and `accepted` invites. Once the invite state changes to `expired`, `removed`, `declined` and `cancelled` the seat
+is freed up again. The reason for `pending` invites to take up seats are to prevent users from using up the seats
+on a first-come-first-serve basis.

--- a/docs/docs/concepts/project-membership.mdx
+++ b/docs/docs/concepts/project-membership.mdx
@@ -29,13 +29,14 @@ with the condition that the link is still valid.
 
 ## Permissions
 
-Only project `owners` can invite more members to a project. Any invited member will
-automatically have the `developer` role assigned, thus preventing any new member from removing members or adding new ones.
+Only project `owners` can invite more members to a project. Any invited member
+will automatically have the `developer` role assigned, thus preventing any new
+member from removing members or adding new ones.
 
 :::note
 
-It is currently not possible to elevate a member from `developer` to `owner`, but will become possible
-in the future.
+It is currently not possible to elevate a member from `developer` to `owner`,
+but will become possible in the future.
 
 :::
 
@@ -49,9 +50,9 @@ prevent users from using up the seats on a first-come, first-served basis,
 leading to more invites sent than member slot availability.
 
 There are two ways to free up member seats:
+
 - Remove a member from the project will result in a `removed` status.
 - Cancel a `pending` invite will result in a `cancelled` status.
-
 
 ## Invite State and Validity
 
@@ -73,11 +74,13 @@ be either `accepted`, `declined`, `expired` or `cancelled`. Only the subject can
 
 [![](https://mermaid.ink/img/pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)](https://mermaid.live/edit/#pako:eNqN0s1OxCAQB_BXIXM024vHHjzpE3i0HmZhumL4aKZDs2az7y6Usmo0sT0Q8uc3MKFcQEdD0MMsKPRo8cTou-VeDUHl7-XuVXXdg7JhsUI1q_M1nigYG06qVzEozYTFVNWWCkOtaRIy1c3p-E5atvS3NqSdDXs1nSfLK8ZRiBUqTSxogzKJUWz8ox-NQZNz7QjUEnkLK67jrZHalSP5WVGjalsbO-jX6Tswk4_L_7Ti2z0X3Sq_6TUql-DJ05G41MEBPLFHa_IjuJR9BpC3vD5An6eGRkxOBhjCNdM0mfyPn4zN20E_opvpAJgkPn8EDb1wooa2t7Sp6ydFEswT)
 
-The link is only valid if it has no user account linked to it or has not expired.
-Once the link has been successfully linked to the user account, the invite will appear in the user's notification
-panel. Here the user can manage their invites.
+The link is only valid if it has no user account linked to it and has not
+expired. Once the link has been successfully linked to the user account, the
+invite will appear in the user's notification panel. Here the user can manage
+their invites.
 
-Once an invite has been completely removed by the project owner, the invite will also be removed for the invited user.
+Once an invite has been completely removed by the project owner, the invite will
+also be removed for the invited user.
 
 :::note
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -28,6 +28,7 @@
         "Concepts": [
           "concepts/terminology",
           "concepts/project",
+          "concepts/project-invite-membership",
           "concepts/managed-ui",
           "concepts/identity",
           "concepts/services-api",


### PR DESCRIPTION
Project Invites Cloud documentation.
The documentation addresses:
- membership
- invite flows
- invite states
- project seats
- member roles