### PR TITLE
docs: ory cloud password policy

### DIFF
--- a/docs/docs/concepts/password-policy.mdx
+++ b/docs/docs/concepts/password-policy.mdx
@@ -5,12 +5,12 @@ title: Password Policy
 
 Password-based authentication flows are subject to frequent abuse through social
 engineering, password guessing and phishing attacks.  
-Ory Cloud implements measures to provide high security for password-based
-flows. The Ory Cloud password policy follows standards by the _National Cyber Security
+Ory Cloud implements measures to provide high security for password-based flows.
+The Ory Cloud password policy follows standards by the _National Cyber Security
 Centre_
 ([`NCSC`](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach))
-and _National Institute of Standards and
-Technology_ ([`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html)) as well as
+and _National Institute of Standards and Technology_
+([`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html)) as well as
 [leading](https://www.troyhunt.com/passwords-evolved-authentication-guidance-for-the-modern-era/)
 security researchers.
 

--- a/docs/docs/concepts/password-policy.mdx
+++ b/docs/docs/concepts/password-policy.mdx
@@ -6,30 +6,35 @@ title: Password Policy
 Password-based authentication flows are subject to frequent abuse through social
 engineering, password guessing and phishing attacks.  
 Ory Cloud implements measures to provide high security for password-based
-flows.  
-The Ory Cloud password policy is based on recommendations by the
-[`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html) and
-[`NCSC`](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach)
-institutes among
-[others](https://www.troyhunt.com/passwords-evolved-authentication-guidance-for-the-modern-era/).
+flows. The Ory Cloud password policy follows standards by the _National Cyber Security
+Centre_
+([`NCSC`](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach))
+and _National Institute of Standards and
+Technology_ ([`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html)) as well as
+[leading](https://www.troyhunt.com/passwords-evolved-authentication-guidance-for-the-modern-era/)
+security researchers.
 
-- The password must at least be 8 characters long and all characters (unicode,
-  ASCII) must be allowed.
+### Default Password Policy
+
+- The password must by default at least be 8 characters long and all characters
+  (unicode, ASCII) are allowed.
 - Ory Cloud makes sure the password is not similar to the username/email or
   other credentials.  
   To ensure the password is different, Ory Cloud enforces a minimum
-  [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
-  (measuring how much two strings resemble each other). It also makes sure no
-  significant strings of the credentials are part of the password.
-- Ory Cloud checks all passwords against the
-  [`HIBP`](https://haveibeenpwned.com/) API.  
-  `HIBP` provides a open database of leaked passwords. Every password sent to
-  `HIBP` is SHA-1 hashed and anonymized, so there is no compromise of user
-  credentials.
-- Ory Cloud does not require or prohibit a mixture or repeated characters.
+  [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). It
+  also makes sure no significant strings of the credentials are part of the
+  password. For example if an users email is `bob@example.com`, `bob24` would
+  not be a valid password.
+- Ory Cloud checks all passwords against a database of known leaked passwords
+  through the [`HIBP`](https://haveibeenpwned.com/) API.  
+  Breached or leaked password detection uses anonymized data.
 
-For a more detailed explanation of the concept of these policies please visit
-the
+- Ory Cloud does not require or prohibit a mixture or repeated characters
+  following to [`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html)
+  guidelines.
+
+For a more detailed explanation on why this is the default password policy for
+Ory Cloud please visit the
 [Security Profiles document](https://www.ory.sh/kratos/docs/next/concepts/security/#password-policy/).
 
 ### Custom User Interface

--- a/docs/docs/concepts/password-policy.mdx
+++ b/docs/docs/concepts/password-policy.mdx
@@ -5,7 +5,8 @@ title: Password Policy
 
 Password-based authentication flows are subject to frequent abuse through social
 engineering, password guessing and phishing attacks.  
-Ory Cloud implements measures to provide high security for password-based flows.  
+Ory Cloud implements measures to provide high security for password-based
+flows.  
 The Ory Cloud password policy is based on recommendations by the
 [`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html) and
 [`NCSC`](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach)
@@ -33,8 +34,10 @@ the
 
 ### Custom User Interface
 
-When using your own user interface, we recommend the following password policies
-to ensure security and user experience:
+When using your
+[own user interface](https://www.ory.sh/kratos/docs/next/concepts/ui-user-interface),
+we recommend the following password policies to ensure security and good user
+experience:
 
 - Allows the pasting of credentials in login etc. forms.
 - Allow making the password visible through a modal.

--- a/docs/docs/concepts/password-policy.mdx
+++ b/docs/docs/concepts/password-policy.mdx
@@ -28,7 +28,6 @@ security researchers.
 - Ory Cloud checks all passwords against a database of known leaked passwords
   through the [`HIBP`](https://haveibeenpwned.com/) API.  
   Breached or leaked password detection uses anonymized data.
-
 - Ory Cloud does not require or prohibit a mixture or repeated characters
   following to [`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html)
   guidelines.

--- a/docs/docs/concepts/password-policy.mdx
+++ b/docs/docs/concepts/password-policy.mdx
@@ -1,0 +1,46 @@
+---
+id: password-policy
+title: Password Policy
+---
+
+Password-based authentication flows are subject to frequent abuse through social
+engineering, password guessing and phishing attacks.  
+Ory Cloud implements measures to provide high security for password-based flows.  
+The Ory Cloud password policy is based on recommendations by the
+[`NIST`](https://pages.nist.gov/800-63-3/sp800-63b.html) and
+[`NCSC`](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach)
+institutes among
+[others](https://www.troyhunt.com/passwords-evolved-authentication-guidance-for-the-modern-era/).
+
+- The password must at least be 8 characters long and all characters (unicode,
+  ASCII) must be allowed.
+- Ory Cloud makes sure the password is not similar to the username/email or
+  other credentials.  
+  To ensure the password is different, Ory Cloud enforces a minimum
+  [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+  (measuring how much two strings resemble each other). It also makes sure no
+  significant strings of the credentials are part of the password.
+- Ory Cloud checks all passwords against the
+  [`HIBP`](https://haveibeenpwned.com/) API.  
+  `HIBP` provides a open database of leaked passwords. Every password sent to
+  `HIBP` is SHA-1 hashed and anonymized, so there is no compromise of user
+  credentials.
+- Ory Cloud does not require or prohibit a mixture or repeated characters.
+
+For a more detailed explanation of the concept of these policies please visit
+the
+[Security Profiles document](https://www.ory.sh/kratos/docs/next/concepts/security/#password-policy/).
+
+### Custom User Interface
+
+When using your own user interface, we recommend the following password policies
+to ensure security and user experience:
+
+- Allows the pasting of credentials in login etc. forms.
+- Allow making the password visible through a modal.
+- Do not show password hints to unauthenticated users.
+- Do not expire passwords.
+
+For a more detailed explanation of the concepts of these guidelines please visit
+the
+[Security Profiles document](https://www.ory.sh/kratos/docs/next/concepts/security/#user-interface-guidelines).

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -36,7 +36,8 @@
           "concepts/redirects",
           "concepts/session",
           "concepts/emails",
-          "ecosystem/api-design"
+          "ecosystem/api-design",
+          "concepts/password-policy"
         ]
       },
       "reference/api",


### PR DESCRIPTION
It is pretty similar to https://www.ory.sh/kratos/docs/next/concepts/security/#password-policy

But it describes the currently implemented password policy in Ory Cloud.
