### PR TITLE
feat: markdownlint

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,19 @@
+name: Lint Markdown with markdownlint
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  markdownlint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Lint files
+      uses: avto-dev/markdown-lint@v1.5.0
+      with:
+        config: './docs/.markdownlint.yml'
+        args: './docs/docs/**/*.+(md|mdx)'
+

--- a/docs/markdownlint.yml
+++ b/docs/markdownlint.yml
@@ -1,0 +1,154 @@
+---
+# Base Markdownlint configuration
+# Extended Markdownlint configuration in doc/.markdownlint/
+default: true
+first-header-h1: false
+header-style:
+  style: "atx"
+ul-style:
+  style: "dash"
+no-trailing-spaces: false
+line-length: false
+no-duplicate-header:
+  allow_different_nesting: true
+no-trailing-punctuation:
+  punctuation: ".,;:!。，；：！？"
+ol-prefix:
+  style: "one"
+no-inline-html: false
+hr-style:
+  style: "---"
+no-emphasis-as-heading: false
+first-line-h1: false
+code-block-style:
+  style: "fenced"
+emphasis-style: false
+strong-style: false
+no-bare-urls: false
+no-space-in-code: false
+MD029: false
+proper-names:
+  names: [
+    "Akismet",
+    "Alertmanager",
+    "API",
+    "Asana",
+    "Auth0",
+    "Authentiq",
+    "Azure",
+    "Bamboo",
+    "Bitbucket",
+    "Bugzilla",
+    "CAS",
+    "CentOS",
+    "Consul",
+    "Debian",
+    "DevOps",
+    "Docker",
+    "DockerSlim",
+    "Elasticsearch",
+    "Facebook",
+    "fastlane",
+    "fluent-plugin-redis-slowlog",
+    "GDK",
+    "Geo",
+    "Git LFS",
+    "git-annex",
+    "git-sizer",
+    "Gitaly",
+    "GitHub",
+    "GitLab Geo",
+    "GitLab Monitor",
+    "GitLab Operator",
+    "GitLab Pages",
+    "GitLab Rails",
+    "GitLab Runner",
+    "GitLab Shell",
+    "GitLab Workhorse",
+    "GitLab",
+    "Gitleaks",
+    "Gmail",
+    "Google",
+    "Grafana",
+    "Gzip",
+    "Helm",
+    "HipChat",
+    "Hydra",
+    "ID",
+    "Ingress",
+    "jasmine-jquery",
+    "JavaScript",
+    "Jaeger",
+    "Jenkins",
+    "Jira",
+    "Jira Cloud",
+    "Jira Server",
+    "jQuery",
+    "JupyterHub",
+    "Karma",
+    "Kerberos",
+    "Keto",
+    "Knative",
+    "Kubernetes",
+    "Kratos",
+    "LDAP",
+    "Let's Encrypt",
+    "Markdown",
+    "markdownlint",
+    "Mattermost",
+    "Microsoft",
+    "Minikube",
+    "MinIO",
+    "ModSecurity",
+    "NGINX Ingress",
+    "NGINX",
+    "OAuth",
+    "OAuth 2",
+    "OmniAuth",
+    "Omnibus GitLab",
+    "OpenID",
+    "OpenShift",
+    "Ory",
+    "Ory Keto",
+    "Ory Hydra",
+    "Ory Kratos",
+    "Ory Oathkeeper",
+    "Oathkeeper",
+    "PgBouncer",
+    "PostgreSQL",
+    "Praefect",
+    "Prometheus",
+    "Puma",
+    "puma-worker-killer",
+    "Python",
+    "Rake",
+    "Redis",
+    "Redmine",
+    "reCAPTCHA",
+    "Ruby",
+    "runit",
+    "Salesforce",
+    "SAML",
+    "Sentry",
+    "Sidekiq",
+    "Shibboleth",
+    "Slack",
+    "SMTP",
+    "SpotBugs",
+    "SSH",
+    "Skaffold",
+    "Tiller",
+    "TOML",
+    "Trello",
+    "Trello Power-Ups",
+    "TypeScript",
+    "Twitter",
+    "Ubuntu",
+    "Ultra Auth",
+    "Unicorn",
+    "unicorn-worker-killer",
+    "URL",
+    "WebdriverIO",
+    "YouTrack"
+  ]
+  code_blocks: false


### PR DESCRIPTION
adds the markdownlint configuration and github action.
this already provides a good baseline for uniform markdown formatting. 
with vale we can then add styles for the wording.

i think this is the feature you also requested:
https://github.com/markdownlint/markdownlint/issues/25