### PR TITLE
fix: use HTTP 303 instead of 302 for selfservice redirects

### DIFF
--- a/docs/kratos/self-service.mdx
+++ b/docs/kratos/self-service.mdx
@@ -151,7 +151,7 @@ import DomainWarning from '@site/src/theme/DomainWarning'
 
 <DomainWarning />
 
-Once stored, the Browser is HTTP 302 redirected to the flow's configured UI URL
+Once stored, the Browser is HTTP 303 redirected to the flow's configured UI URL
 (e.g. `selfservice.flows.login.ui_url`), appending the flow ID as the `flow` URL
 Query Parameter. Also included are HTTP cookies such as Anti-CSRF cookies.
 
@@ -429,7 +429,7 @@ requests.
 
 :::info
 
-Ory Kratos and your UI must be on the hosted on same top level domain! You can
+Ory Kratos and your UI must be hosted on same top level domain! You can
 not host Ory Kratos and your UI on separate top level domains:
 
 - `kratos.bar.com` and `ui.bar.com` will work;

--- a/docs/kratos/self-service/flows/account-recovery.mdx
+++ b/docs/kratos/self-service/flows/account-recovery.mdx
@@ -277,7 +277,7 @@ $ curl -s -i -X GET \
     -H "Accept: text/html" \
     https://playground.projects.oryapis.com/api/kratos/public/self-service/recovery/browser
 
-HTTP/2 302
+HTTP/2 303
 date: Fri, 09 Jul 2021 12:50:38 GMT
 content-type: text/html; charset=utf-8
 content-length: 120
@@ -288,10 +288,10 @@ vary: Origin
 vary: Cookie
 strict-transport-security: max-age=15724800; includeSubDomains
 
-<a href="https://playground.projects.oryapis.com/hosted/recovery?flow=33964b22-c364-4217-b6fc-5f381d142d65">Found</a>.
+<a href="https://playground.projects.oryapis.com/hosted/recovery?flow=33964b22-c364-4217-b6fc-5f381d142d65">See Other</a>.
 ```
 
-The server responds with a HTTP 302 redirect to the Recovery UI, appending the
+The server responds with a HTTP 303 redirect to the Recovery UI, appending the
 `?flow=<flow-id>` query parameter (see the curl example) to the URL configured
 here:
 
@@ -540,7 +540,7 @@ $ curl -H "Accept: application/json" -s \
 
 The form payloads are then submitted to Ory Kratos which follows up with:
 
-- An HTTP 302 Found redirect pointing to the Registration UI for Browser
+- An HTTP 303 See Other redirect pointing to the Registration UI for Browser
   Clients;
 - An `application/json` response for API Clients and Client-Side Browser
   applications (e.g. Single Page Apps).
@@ -552,7 +552,7 @@ validation errors such as a malformed email:
 
 <CodeTabs items={getFlowMethodLinkWithErrors} />
 
-When validation errors happen, browser clients receive a HTTP 302 Found redirect
+When validation errors happen, browser clients receive a HTTP 303 See Other redirect
 to the Recovery Flow UI, containing the Recovery Flow ID which includes the
 error payloads.
 
@@ -568,7 +568,7 @@ On successful submission, an email will be sent to the provided address:
 ## Unsuccessful Recovery
 
 If the recovery challenge (e.g. the link in the recovery email) is invalid or
-expired, the user will be HTTP 302 redirected to the Recovery UI.
+expired, the user will be HTTP 303 redirected to the Recovery UI.
 
 :::note
 
@@ -586,7 +586,7 @@ Please keep in mind that this part of the flow always involves a Browser!
 
 ## Successful Recovery
 
-Completing account recovery always results in a HTTP 302 redirect with a Ory
+Completing account recovery always results in a HTTP 303 redirect with a Ory
 Kratos Login Session Cookie to the Settings UI with a Settings Flow prompting
 the user to update their password or credentials:
 

--- a/docs/kratos/self-service/flows/user-login.mdx
+++ b/docs/kratos/self-service/flows/user-login.mdx
@@ -131,7 +131,7 @@ strict-transport-security: max-age=15724800; includeSubDomains
 <a href="https://playground.projects.oryapis.com/hosted/login?flow=3fc63726-8461-43f4-974a-5579ff4174f1">See Other</a>.
 ```
 
-The server responds with a HTTP 302 redirect to the Login UI, appending the
+The server responds with a HTTP 303 redirect to the Login UI, appending the
 `?flow=<flow-id>` query parameter (see the curl example) to the URL configured
 here:
 
@@ -476,7 +476,7 @@ $ curl -H "Accept: application/json" -s \
 
 The form payloads are then submitted to Ory Kratos which follows up with:
 
-- An HTTP 302 Found redirect pointing to the Login UI for Browser Clients;
+- An HTTP 303 See Other redirect pointing to the Login UI for Browser Clients;
 - An `application/json` response for API Clients and Client-Side Browser
   applications (e.g. Single Page Apps).
 
@@ -488,7 +488,7 @@ missing identifier or password, or invalid credentials:
 
 <CodeTabs items={getFlowMethodPasswordWithErrors} />
 
-When validation errors happen, browser clients receive a HTTP 302 Found redirect
+When validation errors happen, browser clients receive a HTTP 303 See Other redirect
 to the Login Flow UI, containing the Login Flow ID which includes the error
 payloads.
 
@@ -519,14 +519,14 @@ Completing the login behaves differently for Browser and API Clients.
 
 ### Server-Side Browser Clients
 
-When the login is completed successfully, Ory Kratos responds with a HTTP 302
+When the login is completed successfully, Ory Kratos responds with a HTTP 303
 Redirect to the
 [configured redirect URL](../../concepts/browser-redirect-flow-completion).
-Alongside the HTTP 302 Redirect is a `Set-Cookie` header which contains the Ory
+Alongside the HTTP 303 Redirect is a `Set-Cookie` header which contains the Ory
 Kratos Login Session Cookie:
 
 ```
-HTTP/1.1 302 Found
+HTTP/1.1 303 See Other
 Cache-Control: 0
 Location: http://127.0.0.1:4455/
 Set-Cookie: csrf_token=b8OebRPTPr5ow23mA5gIZmFNLeuMbv8pZz1jT1Ex7ys=; Path=/; Domain=127.0.0.1; Max-Age=31536000; HttpOnly

--- a/docs/kratos/self-service/flows/user-registration.mdx
+++ b/docs/kratos/self-service/flows/user-registration.mdx
@@ -110,7 +110,7 @@ Kratos, your Registration UI, and the end-user's browser:
 
 <SelfServiceBrowserFlow
   flows={['registration']}
-  success="User created and successful HTTP 302 redirect"
+  success="User created and successful HTTP 303 redirect"
   interactions={['"Sign up"']}
 />
 
@@ -136,7 +136,7 @@ strict-transport-security: max-age=15724800; includeSubDomains
 <a href="https://playground.projects.oryapis.com/hosted/registration?flow=6c2ae96c-8486-42f0-91f9-f654eccd09fb">See Other</a>.
 ```
 
-The server responds with a HTTP 302 redirect to the Registration UI, appending
+The server responds with a HTTP 303 redirect to the Registration UI, appending
 the `?flow=<flow-id>` query parameter (see the curl example) to the configured
 registration URL.
 
@@ -540,7 +540,7 @@ $ curl -H "Accept: application/json" -s \
 
 The form payloads are then submitted to Ory Kratos which follows up with:
 
-- An HTTP 302 Found redirect pointing to the Registration UI for Browser
+- An HTTP 303 See Other redirect pointing to the Registration UI for Browser
   Clients;
 - An `application/json` response for API Clients and Client-Side Browser
   applications (e.g. Single Page Apps).
@@ -589,7 +589,7 @@ validation errors:
 
 <CodeTabs items={getFlowMethodPasswordWithErrors} />
 
-When validation errors happen, browser clients receive a HTTP 302 Found redirect
+When validation errors happen, browser clients receive a HTTP 303 See Other redirect
 to the Registration Flow UI, containing the Registration Flow ID which includes
 the error payloads.
 
@@ -700,17 +700,17 @@ typically not an issue if you follow the guidelines in the
 ### Server-Side Browser Clients
 
 When the registration is completed successfully, Ory Kratos responds with a HTTP
-302 Redirect to the
+303 Redirect to the
 [configured redirect URL](../../concepts/browser-redirect-flow-completion.mdx).
 
 #### With Auto-Login on Registration
 
 If the `session` after hook is enabled, a `Set-Cookie` HTTP Header is set
-alongside the HTTP 302 redirect which contains the Ory Kratos Login Session
+alongside the HTTP 303 redirect which contains the Ory Kratos Login Session
 Cookie:
 
 ```
-HTTP/1.1 302 Found
+HTTP/1.1 303 See Other
 Cache-Control: 0
 Location: http://127.0.0.1:4455/
 Set-Cookie: csrf_token=b8OebRPTPr5ow23mA5gIZmFNLeuMbv8pZz1jT1Ex7ys=; Path=/; Domain=127.0.0.1; Max-Age=31536000; HttpOnly
@@ -803,11 +803,11 @@ When the registration is completed successfully, Ory Kratos responds with a HTTP
 #### With Auto-Login on Registration
 
 If the `session` after hook is enabled, a `Set-Cookie` HTTP Header is set
-alongside the HTTP 302 redirect which contains the Ory Kratos Login Session
+alongside the HTTP 303 redirect which contains the Ory Kratos Login Session
 Cookie:
 
 ```
-HTTP/1.1 302 Found
+HTTP/1.1 303 See Other
 Cache-Control: 0
 Location: http://127.0.0.1:4455/
 Set-Cookie: csrf_token=b8OebRPTPr5ow23mA5gIZmFNLeuMbv8pZz1jT1Ex7ys=; Path=/; Domain=127.0.0.1; Max-Age=31536000; HttpOnly

--- a/docs/kratos/self-service/flows/user-settings.mdx
+++ b/docs/kratos/self-service/flows/user-settings.mdx
@@ -220,7 +220,7 @@ Kratos, your Settings UI, and the end-user's browser:
 
 <SelfServiceBrowserFlow
   flows={['settings']}
-  success="Identity Updated and HTTP 302 redirect to Success Flow"
+  success="Identity Updated and HTTP 303 redirect to Success Flow"
   interactions={['"Save Profile Changes"']}
 />
 
@@ -262,7 +262,7 @@ $ curl -s -i -X GET \
     -H "Accept: text/html" \
     https://playground.projects.oryapis.com/api/kratos/public/self-service/settings/browser
 
-HTTP/2 302
+HTTP/2 303
 date: Fri, 09 Jul 2021 11:07:48 GMT
 content-type: text/html; charset=utf-8
 content-length: 120
@@ -272,10 +272,10 @@ vary: Origin
 vary: Cookie
 strict-transport-security: max-age=15724800; includeSubDomains
 
-<a href="https://playground.projects.oryapis.com/hosted/settings?flow=95efce11-0bd2-4f55-abce-180ced8b69d7">Found</a>.
+<a href="https://playground.projects.oryapis.com/hosted/settings?flow=95efce11-0bd2-4f55-abce-180ced8b69d7">See Other</a>.
 ```
 
-The server responds with a HTTP 302 redirect to the Settings UI, appending the
+The server responds with a HTTP 303 redirect to the Settings UI, appending the
 `?flow=<flow-id>` query parameter (see the curl example) to the configured
 settings URL.
 
@@ -647,12 +647,12 @@ a future version, which is partially tracked as
 
 The form payloads are then submitted to Ory Kratos which follows up with:
 
-- An HTTP 302 Found redirect pointing to the Registration UI for Browser
+- An HTTP 303 See Other redirect pointing to the Registration UI for Browser
   Clients;
 - An `application/json` response for API Clients and Client-Side Browser
   applications (e.g. Single Page Apps).
 
-When validation errors happen, browser clients receive a HTTP 302 Found redirect
+When validation errors happen, browser clients receive a HTTP 303 See Other redirect
 to the Settings Flow UI, containing the Settings Flow ID which includes the
 error payloads. For API Clients, the server typically responds with HTTP 400 Bad
 Request `application/json` and the Settings Flow in the response payload as
@@ -692,7 +692,7 @@ Completing the settings update behaves differently for Browser and API Clients.
 ### Server-Side Browser Clients
 
 When the profile update is completed successfully, Ory Kratos responds with a
-HTTP 302 Redirect to the Settings UI which now contains the success state
+HTTP 303 Redirect to the Settings UI which now contains the success state
 (`state: success`) as well as the updated identity:
 
 ```shell-session

--- a/docs/kratos/self-service/flows/verify-email-account-activation.mdx
+++ b/docs/kratos/self-service/flows/verify-email-account-activation.mdx
@@ -254,7 +254,7 @@ $ curl -s -i -X GET \
     -H "Accept: text/html" \
     https://playground.projects.oryapis.com/api/kratos/public/self-service/verification/browser
 
-HTTP/2 302
+HTTP/2 303
 date: Fri, 09 Jul 2021 13:08:00 GMT
 content-type: text/html; charset=utf-8
 content-length: 124
@@ -265,10 +265,10 @@ vary: Origin
 vary: Cookie
 strict-transport-security: max-age=15724800; includeSubDomains
 
-<a href="https://playground.projects.oryapis.com/hosted/verification?flow=ba66958a-5f15-4b8f-88f9-52b35020db5c">Found</a>.
+<a href="https://playground.projects.oryapis.com/hosted/verification?flow=ba66958a-5f15-4b8f-88f9-52b35020db5c">See Other</a>.
 ```
 
-The server responds with a HTTP 302 redirect to the Verification UI, appending
+The server responds with a HTTP 303 redirect to the Verification UI, appending
 the `?flow=<flow-id>` query parameter (see the curl example) to the URL
 configured here:
 
@@ -562,7 +562,7 @@ $ curl -H "Accept: application/json" -s \
 
 The form payloads are then submitted to Ory Kratos which follows up with:
 
-- An HTTP 302 Found redirect pointing to the Registration UI for Browser
+- An HTTP 303 See Other redirect pointing to the Registration UI for Browser
   Clients;
 - An `application/json` response for API Clients and Client-Side Browser
   applications (e.g. Single Page Apps).
@@ -574,7 +574,7 @@ validation errors such as a malformed email:
 
 <CodeTabs items={getFlowMethodLinkWithErrors} />
 
-When validation errors happen, browser clients receive a HTTP 302 Found redirect
+When validation errors happen, browser clients receive a HTTP 303 See Other redirect
 to the Verification Flow UI, containing the Verification Flow ID which includes
 the error payloads.
 
@@ -590,7 +590,7 @@ On successful submission, an email will be sent to the provided address:
 ## Unsuccessful Verification
 
 If the verification challenge (e.g. the link in the verification email) is
-invalid or expired, the user will be HTTP 302 redirected to the Verification UI.
+invalid or expired, the user will be HTTP 303 redirected to the Verification UI.
 
 :::note
 


### PR DESCRIPTION
## Related issue(s)

[#1969
](https://github.com/ory/kratos/issues/1969)
## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
 