### PR TITLE
chore: fix outdated doc title

### DIFF
--- a/docs/hydra/concepts/oauth2.mdx
+++ b/docs/hydra/concepts/oauth2.mdx
@@ -111,7 +111,7 @@ A typical OAuth 2.0 flow looks as follows:
 :::note
 
 Please read the section about OAuth2 Scope in
-[Read this before learning OAuth2 / OpenID Connect](./before-oauth2.mdx).
+[**Do You Need OAuth2?**](./before-oauth2.mdx).
 
 :::
 


### PR DESCRIPTION
update outdated document title