### PR TITLE
fix: vale github action

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -19,6 +19,8 @@ jobs:
             https://github.com/errata-ai/Microsoft/releases/latest/download/Microsoft.zip
             https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
           config: https://raw.githubusercontent.com/ory/docs/${{ github.sha }}/docs/.vale.ini
+          onlyAnnotateModifiedLines: true
+          debug: true
 
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Changees the Vale Github action to fail silently and only output annotations for lines that got changed.