### PR TITLE
docs: Sync Docker image versions

### DIFF
--- a/docs/hydra/configure-deploy.mdx
+++ b/docs/hydra/configure-deploy.mdx
@@ -219,7 +219,7 @@ $ docker run -d \
   --network hydraguide \
   -e HYDRA_ADMIN_URL=https://ory-hydra-example--hydra:4445 \
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  oryd/hydra-login-consent-node:v1.3.2
+  oryd/hydra-login-consent-node:v1.10.6
 
 # Let's check if it's running ok:
 $ docker logs ory-hydra-example--consent


### PR DESCRIPTION
Before one version was pulled but another one was ran.

See `$ docker pull oryd/hydra-login-consent-node:v1.10.6` above the line I changed.