### PR TITLE
docs: clarify redirects json

### DIFF
--- a/docs/kratos/concepts/browser-redirect-flow-completion.mdx
+++ b/docs/kratos/concepts/browser-redirect-flow-completion.mdx
@@ -149,5 +149,6 @@ https://public.kratos/self-service/registration/browser?after_verification_retur
 
 ## JSON
 
-This feature is currently in prototype phase and will be documented at a later
-stage.
+Requests from API clients - for example AJAX - are identified by the `Accept: application/json`
+header and return a JSON response. If no redirection URL is set for the flow, the
+`default_redirect_to` URL will be used for most flows.


### PR DESCRIPTION
You would use the same config for JSON or browser redirect, just use a different Accept header, right? 
Then we could restructure this doc a bit. 
Anyway let me know this is enough.