### PR TITLE
docs: updating claims on token refresh

### DIFF
--- a/docs/hydra/advanced.md
+++ b/docs/hydra/advanced.md
@@ -184,59 +184,6 @@ compatibility):
 }
 ```
 
-#### Updating claims at token refresh
-
-Hydra can be configured to retrieve updated token claims from an endpoint at
-token refresh, which provides updated claims for a given subject and scopes.
-This is similar to accepting consent request, where the application provides the
-session data by calling Hydra Admin API.
-
-:::note
-
-This endpoint is called _before_ any logic in Ory Hydra is executed. If the
-hook, for example, returns an error, the refresh token will remain unused!
-
-:::note
-
-You can configure `oauth2.refresh_token_hook` config key:
-
-```yaml
-oauth2:
-  refresh_token_hook: https://my-example.app/token-refresh-hook
-```
-
-Hydra makes a `POST` request to this hook with the following payload:
-
-```json
-{
-  "subject": "foo",
-  "client_id": "bar",
-  "granted_scopes": ["openid", "offline"],
-  "granted_audience": []
-}
-```
-
-Hook has to respond with `200 OK` and updated session data (i.e. "extra" claims)
-for a token refresh to continue:
-
-```json
-{
-  "session": {
-    "access_token": {
-      "foo": "bar"
-    },
-    "id_token": {
-      "bar": "baz"
-    }
-  }
-}
-```
-
-This will overwrite existing session data from the original consent request.
-
-Hydra will gracefully deny refresh requests if the hook responds with
-`403 Forbidden`. Any other response from the hook will fail refresh requests.
-
 ### OAuth 2.0 Client Authentication with private/public keypairs
 
 Please head over to the

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -54,7 +54,7 @@ import TabItem from '@theme/TabItem';
 
 ### Webhook configuration
 
-The refresh token hook endpoint must accept the following payload format sent by Hydra: 
+The refresh token hook endpoint must accept the following payload format: 
 
 ```json
 {
@@ -88,5 +88,5 @@ The token subject is never overridden.
 
 ## Rejecting token refresh
 
-To gracefully reject token refresh, the hook must return a `403 Forbidden` response. 
-Any other response results in a failure of the token refresh and, as a result, failure of the entire flow. 
+To gracefully reject token contents update, the hook must return a `403 Forbidden` response. 
+Any other response results in a failure of the token update and, as a result, failure of the entire token refresh flow. 

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -1,0 +1,92 @@
+---
+id: claims-at-refresh
+title: Updating claims at token refresh
+---
+
+## Overview
+
+The Hydra OAuth2 and OpenID Connect server comes with a mechanism that allows updating `id_token` and `access_token` 
+when a registered client sends a token refresh request. The flow is realized by calling the defined refresh token hook endpoint 
+which returns updated data. 
+
+If the data provided by the webhook is different from the data the client sends, the webhook overwrites the session data with a new set. 
+
+:::note
+
+The hook is called before any other logic is executed. If the hook execution fails, 
+the entire token refresh flow fails and the `refresh_token` remains unused.
+
+::: 
+
+
+## Configuration
+
+To enable the token refresh webhook, configure the `oauth2.refresh_token_hook` key in the Hydra configuration: 
+
+```yaml
+oauth2:
+  refresh_token_hook: https://my-example.app/token-refresh-hook
+```
+
+If you're running Hydra locally, you can set this value by exporting the refresh token hook endpoint URL as an environment variable. 
+Run this command: 
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="macos" label="macOS" default>
+
+    export OAUTH2_REFRESH_TOKEN_HOOK=<value>
+
+  </TabItem>
+  <TabItem value="linux" label="Linux">
+
+    export OAUTH2_REFRESH_TOKEN_HOOK=<value>
+  
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+
+    set OAUTH2_REFRESH_TOKEN_HOOK=<value>
+  
+  </TabItem>
+</Tabs>
+
+### Webhook configuration
+
+The refresh token hook endpoint must accept the following payload format sent by Hydra: 
+
+```json
+{
+  "subject": "foo",
+  "client_id": "bar",
+  "granted_scopes": ["openid", "offline"],
+  "granted_audience": []
+}
+```
+
+To update the data, the webhook must return a `200 OK` response and the updated session data in the following format:
+
+```json
+{
+  "session": {
+    "access_token": {
+      "foo": "bar"
+    },
+    "id_token": {
+      "bar": "baz"
+    }
+  }
+}
+```
+
+:::note
+
+The token subject is never overridden.
+
+:::
+
+## Rejecting token refresh
+
+To gracefully reject token refresh, the hook must return a `403 Forbidden` response. 
+Any other response results in a failure of the token refresh and, as a result, failure of the entire flow. 

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -3,8 +3,6 @@ id: claims-at-refresh
 title: Updating claims at token refresh
 ---
 
-## Overview
-
 The Hydra OAuth2 and OpenID Connect server comes with a mechanism that allows updating `id_token` and `access_token` 
 when a registered client sends a token refresh request. The flow is realized by calling the defined refresh token hook endpoint 
 which returns updated data. 
@@ -18,7 +16,6 @@ the entire token refresh flow fails and the `refresh_token` remains unused.
 
 ::: 
 
-
 ## Configuration
 
 To enable the token refresh webhook, configure the `oauth2.refresh_token_hook` key in the Hydra configuration: 
@@ -30,6 +27,8 @@ oauth2:
 
 If you're running Hydra locally, you can set this value by exporting the refresh token hook endpoint URL as an environment variable. 
 Run this command: 
+
+```mdx-code-block
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -51,6 +50,7 @@ import TabItem from '@theme/TabItem';
   
   </TabItem>
 </Tabs>
+```
 
 ### Webhook configuration
 
@@ -85,6 +85,46 @@ To update the data, the webhook must return a `200 OK` response and the updated 
 The token subject is never overridden.
 
 :::
+
+### Updated tokens
+
+The following examples show fragments of tokens updated by a webhook set up with the [example configuration](#webhook-configuration):
+
+```mdx-code-block
+
+<Tabs>
+  <TabItem value="id_token" label="id_token" default>
+
+        "at_hash": "a0iOL0mRPeaJO7Ns0SECnQ",
+        "aud": [
+          "my_client"
+        ],
+        "auth_time": 1647427485,
+        "bar": "baz",
+        "iss": "http://ory.hydra.example/",
+        "sub": "foo@bar.com"
+      }
+
+  </TabItem>
+  <TabItem value="access_token" label="access_token">
+
+        {
+        "active": true,
+        "scope": "openid offline",
+        "client_id": "my_client",
+        "sub": "foo@bar.com",
+        "aud": [],
+        "iss": "http://ory.hydra.example/",
+        "token_type": "Bearer",
+        "token_use": "access_token",
+        "ext": {
+            "foo": "bar"
+        }
+    }
+  
+  </TabItem>
+</Tabs>
+```
 
 ## Rejecting token refresh
 

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -95,32 +95,32 @@ The following examples show fragments of tokens issued after refreshing:
 <Tabs>
   <TabItem value="id_token" label="id_token" default>
     <CodeBlock language="json">{` 
-      {
-        "aud": [
-          "my_client"
-        ],
-        "auth_time": 1647427485,
-        "bar": "baz",
-        "iss": "http://ory.hydra.example/",
-        "sub": "foo@bar.com"
-      }
+  {
+    "aud": [
+      "my_client"
+    ],
+    "auth_time": 1647427485,
+    "bar": "baz",
+    "iss": "http://ory.hydra.example/",
+    "sub": "foo@bar.com"
+  }
     `}</CodeBlock>
   </TabItem>
   <TabItem value="access_token" label="access_token">
     <CodeBlock language="json">{`
-        {
-          "active": true,
-          "scope": "openid offline",
-          "client_id": "my_client",
-          "sub": "foo@bar.com",
-          "aud": [],
-          "iss": "http://ory.hydra.example/",
-          "token_type": "Bearer",
-          "token_use": "access_token",
-          "ext": {
-              "foo": "bar"
-            }
-        }  
+  {
+    "active": true,
+    "scope": "openid offline",
+    "client_id": "my_client",
+    "sub": "foo@bar.com",
+    "aud": [],
+    "iss": "http://ory.hydra.example/",
+    "token_type": "Bearer",
+    "token_use": "access_token",
+    "ext": {
+        "foo": "bar"
+      }
+  }  
      `}</CodeBlock>
   </TabItem>
 </Tabs>

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -95,32 +95,32 @@ The following examples show fragments of tokens issued after refreshing:
 <Tabs>
   <TabItem value="id_token" label="id_token" default>
     <CodeBlock language="json">{` 
-  {
-    "aud": [
-      "my_client"
-    ],
-    "auth_time": 1647427485,
-    "bar": "baz",
-    "iss": "http://ory.hydra.example/",
-    "sub": "foo@bar.com"
-  }
+{
+  "aud": [
+    "my_client"
+  ],
+  "auth_time": 1647427485,
+  "bar": "baz",
+  "iss": "http://ory.hydra.example/",
+  "sub": "foo@bar.com"
+}
     `}</CodeBlock>
   </TabItem>
   <TabItem value="access_token" label="access_token">
     <CodeBlock language="json">{`
-  {
-    "active": true,
-    "scope": "openid offline",
-    "client_id": "my_client",
-    "sub": "foo@bar.com",
-    "aud": [],
-    "iss": "http://ory.hydra.example/",
-    "token_type": "Bearer",
-    "token_use": "access_token",
-    "ext": {
-        "foo": "bar"
-      }
-  }  
+{
+  "active": true,
+  "scope": "openid offline",
+  "client_id": "my_client",
+  "sub": "foo@bar.com",
+  "aud": [],
+  "iss": "http://ory.hydra.example/",
+  "token_type": "Bearer",
+  "token_use": "access_token",
+  "ext": {
+      "foo": "bar"
+    }
+}  
      `}</CodeBlock>
   </TabItem>
 </Tabs>

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -36,22 +36,17 @@ token hook endpoint URL as an environment variable. Run this command:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock'
 
 <Tabs>
   <TabItem value="macos" label="macOS" default>
-
-    export OAUTH2_REFRESH_TOKEN_HOOK=<value>
-
+    <CodeBlock language="shell">export OAUTH2_REFRESH_TOKEN_HOOK=value</CodeBlock>
   </TabItem>
   <TabItem value="linux" label="Linux">
-
-    export OAUTH2_REFRESH_TOKEN_HOOK=<value>
-
+    <CodeBlock language="shell">export OAUTH2_REFRESH_TOKEN_HOOK=value</CodeBlock>
   </TabItem>
   <TabItem value="windows" label="Windows">
-
-    set OAUTH2_REFRESH_TOKEN_HOOK=<value>
-
+    <CodeBlock language="shell">set OAUTH2_REFRESH_TOKEN_HOOK=value</CodeBlock> 
   </TabItem>
 </Tabs>
 ```
@@ -99,7 +94,8 @@ The following examples show fragments of tokens issued after refreshing:
 
 <Tabs>
   <TabItem value="id_token" label="id_token" default>
-
+    <CodeBlock language="json">{` 
+      {
         "aud": [
           "my_client"
         ],
@@ -108,24 +104,24 @@ The following examples show fragments of tokens issued after refreshing:
         "iss": "http://ory.hydra.example/",
         "sub": "foo@bar.com"
       }
-
+    `}</CodeBlock>
   </TabItem>
   <TabItem value="access_token" label="access_token">
-
+    <CodeBlock language="json">{`
         {
-        "active": true,
-        "scope": "openid offline",
-        "client_id": "my_client",
-        "sub": "foo@bar.com",
-        "aud": [],
-        "iss": "http://ory.hydra.example/",
-        "token_type": "Bearer",
-        "token_use": "access_token",
-        "ext": {
-            "foo": "bar"
-        }
-    }
-
+          "active": true,
+          "scope": "openid offline",
+          "client_id": "my_client",
+          "sub": "foo@bar.com",
+          "aud": [],
+          "iss": "http://ory.hydra.example/",
+          "token_type": "Bearer",
+          "token_use": "access_token",
+          "ext": {
+              "foo": "bar"
+            }
+        }  
+     `}</CodeBlock>
   </TabItem>
 </Tabs>
 ```

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -3,30 +3,34 @@ id: claims-at-refresh
 title: Updating claims at token refresh
 ---
 
-The Hydra OAuth2 and OpenID Connect server comes with a mechanism that allows updating `id_token` and `access_token` 
-when a registered client sends a token refresh request. The flow is realized by calling the defined refresh token hook endpoint 
-which returns updated data. 
+The Hydra OAuth2 and OpenID Connect server comes with a mechanism that allows
+updating `id_token` and `access_token` when a registered client sends a token
+refresh request. The flow is realized by calling the defined refresh token hook
+endpoint which returns updated data.
 
-If the data provided by the webhook is different from the data the client sends, the webhook overwrites the session data with a new set. 
+If the data provided by the webhook is different from the data the client sends,
+the webhook overwrites the session data with a new set.
 
 :::note
 
-The hook is called before any other logic is executed. If the hook execution fails, 
-the entire token refresh flow fails and the `refresh_token` remains unused.
+The hook is called before any other logic is executed. If the hook execution
+fails, the entire token refresh flow fails and the `refresh_token` remains
+unused.
 
-::: 
+:::
 
 ## Configuration
 
-To enable the token refresh webhook, configure the `oauth2.refresh_token_hook` key in the Hydra configuration: 
+To enable the token refresh webhook, configure the `oauth2.refresh_token_hook`
+key in the Hydra configuration:
 
 ```yaml
 oauth2:
   refresh_token_hook: https://my-example.app/token-refresh-hook
 ```
 
-If you're running Hydra locally, you can set this value by exporting the refresh token hook endpoint URL as an environment variable. 
-Run this command: 
+If you're running Hydra locally, you can set this value by exporting the refresh
+token hook endpoint URL as an environment variable. Run this command:
 
 ```mdx-code-block
 
@@ -42,19 +46,19 @@ import TabItem from '@theme/TabItem';
   <TabItem value="linux" label="Linux">
 
     export OAUTH2_REFRESH_TOKEN_HOOK=<value>
-  
+
   </TabItem>
   <TabItem value="windows" label="Windows">
 
     set OAUTH2_REFRESH_TOKEN_HOOK=<value>
-  
+
   </TabItem>
 </Tabs>
 ```
 
 ### Webhook configuration
 
-The refresh token hook endpoint must accept the following payload format: 
+The refresh token hook endpoint must accept the following payload format:
 
 ```json
 {
@@ -65,7 +69,8 @@ The refresh token hook endpoint must accept the following payload format:
 }
 ```
 
-To update the data, the webhook must return a `200 OK` response and the updated session data in the following format:
+To update the data, the webhook must return a `200 OK` response and the updated
+session data in the following format:
 
 ```json
 {
@@ -120,12 +125,13 @@ The following examples show fragments of tokens issued after refreshing:
             "foo": "bar"
         }
     }
-  
+
   </TabItem>
 </Tabs>
 ```
 
 ## Rejecting token refresh
 
-To gracefully reject token contents update, the hook must return a `403 Forbidden` response. 
-Any other response results in a failure of the token update and, as a result, failure of the entire token refresh flow. 
+To gracefully reject token contents update, the hook must return a
+`403 Forbidden` response. Any other response results in a failure of the token
+update and, as a result, failure of the entire token refresh flow.

--- a/docs/hydra/guides/updating-claims-at-refresh.mdx
+++ b/docs/hydra/guides/updating-claims-at-refresh.mdx
@@ -88,14 +88,13 @@ The token subject is never overridden.
 
 ### Updated tokens
 
-The following examples show fragments of tokens updated by a webhook set up with the [example configuration](#webhook-configuration):
+The following examples show fragments of tokens issued after refreshing:
 
 ```mdx-code-block
 
 <Tabs>
   <TabItem value="id_token" label="id_token" default>
 
-        "at_hash": "a0iOL0mRPeaJO7Ns0SECnQ",
         "aud": [
           "my_client"
         ],

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -288,7 +288,8 @@ module.exports = {
                 'hydra/guides/using-oauth2',
                 'hydra/guides/token-expiration',
                 'hydra/guides/oauth2-token-introspection',
-                'hydra/guides/oauth2-public-spa-mobile'
+                'hydra/guides/oauth2-public-spa-mobile',
+                'hydra/guides/claims-at-refresh'
               ]
             }
           ]


### PR DESCRIPTION
Moved the existing content to a separate doc and made the description clearer.