### PR TITLE
fix: vale linter

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -20,7 +20,6 @@ jobs:
             https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
           config: https://raw.githubusercontent.com/ory/docs/${{ github.sha }}/docs/.vale.ini
           onlyAnnotateModifiedLines: true
-          debug: true
 
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,7 +16,6 @@ jobs:
         uses: errata-ai/vale-action@master
         with:
           styles: |
-            https://github.com/errata-ai/Microsoft/releases/latest/download/Microsoft.zip
             https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
           config: https://raw.githubusercontent.com/ory/docs/${{ github.sha }}/docs/.vale.ini
           onlyAnnotateModifiedLines: true

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -3,5 +3,7 @@ StylesPath = styles
 [*.md]
 BasedOnStyles = write-good, Microsoft
 
+MinAlertLevel = error # suggestion, warning or error
+
 [formats]
 mdx = md

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = styles
 
 [*.md]
-BasedOnStyles = write-good, Microsoft
+BasedOnStyles = write-good
 
 MinAlertLevel = error # suggestion, warning or error
 


### PR DESCRIPTION
- fix: alertLevel Vale
- fix: remove debug mode vale

This sets the alert level of Vale to "error" and removes the "debug" mode, so the CI fails on errors. 
warnings and suggestions should be fixed, but dont make the CI fail (sometimes you need for example "passive voice") 

Also removes the microsoft styleguide, since its overly opinionated. 
We should make our own ruleset for Vale  
