### PR TITLE
fix: build issues with mdx block

### DIFF
--- a/docs/hydra/sdk/go.mdx
+++ b/docs/hydra/sdk/go.mdx
@@ -3,9 +3,6 @@ id: go
 title: Go
 ---
 
-import CodeBlock from '@theme/CodeBlock'
-import { useLatestRelease } from '@site/src/hooks'
-
 Ory SDKs are generated using the
 [openapi-generator](https://github.com/OpenAPITools/openapi-generator). The Ory
 Hydra Go SDK is generated using [`go-swagger`](http://goswagger.io).
@@ -23,6 +20,9 @@ information visit the [Using OAuth2](../guides/using-oauth2.mdx) guide.
 To install the Go SDK, run:
 
 ```mdx-code-block
+import CodeBlock from '@theme/CodeBlock'
+import { useLatestRelease } from '@site/src/hooks'
+
 <CodeBlock className="language-shell">{`go get github.com/ory/hydra-client-go@${useLatestRelease('hydra')}`}</CodeBlock>
 ```
 


### PR DESCRIPTION
@gen1us2k the build was failing on master because the imports were not in an mdx code block. Please always add react code to mdx code blocks to prevent issues like these and some others too :)