### PR TITLE
docs: fix webauthn configuration documentation

### DIFF
--- a/docs/_common/features/webauthn/configuration.mdx
+++ b/docs/_common/features/webauthn/configuration.mdx
@@ -21,22 +21,21 @@ import TabItem from '@theme/TabItem';
   </TabItem>
   <TabItem value="macos" label="Full Config" default>
     <CodeBlock language="yaml" title="config.yml">{`selfservice:
-  flows:
-    methods:
-      webauthn:
-        enabled: true
-        config:
-          # If set to true will use WebAuthn for passwordless flows intead of multi-factor authentication.
-          passwordless: ${props.passwordless || false}
-          rp:
-            # This MUST be your top-level-domain
-            id: example.org
-            # This MUST be the exact URL of the page which will prompt for WebAuthn!
-            # Only the scheme (https / http), host (auth.example.org), and port (4455) are relevant. The
-            # path is irrelevant
-            origin: http://auth.example.org:4455
-            # A display name which will be shown to the user on her/his device.
-            display_name: Ory`}</CodeBlock>
+  methods:
+    webauthn:
+      enabled: true
+      config:
+        # If set to true will use WebAuthn for passwordless flows intead of multi-factor authentication.
+        passwordless: ${props.passwordless || false}
+        rp:
+          # This MUST be your top-level-domain
+          id: example.org
+          # This MUST be the exact URL of the page which will prompt for WebAuthn!
+          # Only the scheme (https / http), host (auth.example.org), and port (4455) are relevant. The
+          # path is irrelevant
+          origin: http://auth.example.org:4455
+          # A display name which will be shown to the user on her/his device.
+          display_name: Ory`}</CodeBlock>
   </TabItem>
 </Tabs>
 ```


### PR DESCRIPTION
Property `methods` should be a direct child to property `selfservice` in the documented config.yml example for webauthn, instead of a child to `flows`.

## Related Issue or Design Document

[https://github.com/ory/kratos/issues/2414](https://github.com/ory/kratos/issues/2414)

## Checklist

- [ X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X ] I have read the [security policy](../security/policy).
- [X ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X ] I have added necessary documentation within the code base (if
      appropriate).
