### PR TITLE
docs: dedicated example document

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -1,0 +1,21 @@
+---
+id: examples
+title: Examples
+---
+
+List of Ory maintained examples:
+
+- kratos-selfservice-ui-react-native
+- https://github.com/ory/kratos-selfservice-ui-react-nextjs
+- https://github.com/ory/kratos-nextjs-react-example
+- kratos-selfservice-ui-node
+- PHP example from docs
+- Flutter example from docs ...
+
+List of community contributed examples:
+
+- https://github.com/ory/examples
+
+List of community examples:
+
+- Examples not in the ory org

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,15 +104,16 @@ module.exports = {
           label: 'Documentation'
         },
         {
+          type: 'doc',
+          position: 'left',
+          docId: 'examples',
+          label: 'Examples'
+        },
+        {
           type: 'docSidebar',
           position: 'left',
           sidebarId: 'opensource',
           label: 'Contributing & Open Source'
-        },
-        {
-          to: 'https://github.com/ory/examples',
-          label: `Examples`,
-          position: 'left'
         },
         {
           to: 'https://www.ory.sh/',


### PR DESCRIPTION
The examples repository is a collection of unmaintained / untested examples. We can link to it, but people should not leave the documentation to find the example they need.

Let's use a dedicated page and add the examples we know that we have automated tests for first (usually the ones we wrote in product dev) in a comprehensive document.