### PR TITLE
fix: dynamic client registration path in hydra docs

### DIFF
--- a/docs/hydra/guides/openid-connect-dynamic-client-registration.mdx
+++ b/docs/hydra/guides/openid-connect-dynamic-client-registration.mdx
@@ -24,17 +24,17 @@ oidc:
 
 Enabling this feature will add listeners to the following four routes at the public endpoint:
 
-- `POST /openid/register` - Register a new OAuth2 Client;
-- `GET /openid/register/<client_id>` - Fetch the OAuth2 Client;
-- `PUT /openid/register/<client_id>` - Update the OAuth2 Client;
-- `DELETE /openid/register/<client_id>` - Delete the OAuth2 Client;
+- `POST /oauth2/register` - Register a new OAuth2 Client;
+- `GET /oauth2/register/<client_id>` - Fetch the OAuth2 Client;
+- `PUT /oauth2/register/<client_id>` - Update the OAuth2 Client;
+- `DELETE /oauth2/register/<client_id>` - Delete the OAuth2 Client;
 
 ## Register OAuth2 & OpenID Connect Clients
 
 If OpenID Connect Dynamic Client Registration is enabled, registering a new OAuth2 Client is as simple as:
 
 ```
-POST /openid/register
+POST /oauth2/register
 Content-Type: application/json
 
 {
@@ -63,7 +63,7 @@ The `POST` endpoint requires the client to authenticate with the `registration_a
 `token_endpoint_auth_method`. It can be used to update the OAuth2 Client.
 
 ```
-PUT /openid/register/{client_id}
+PUT /oauth2/register/{client_id}
 Authorization: Bearer <registration_access_token>
 Content-Type: application/json
 
@@ -95,7 +95,7 @@ The `GET` endpoint requires the client to authenticate with the `registration_ac
 `token_endpoint_auth_method`. It can be used to retrieve the OAuth2 Client.
 
 ```
-GET /openid/register/{client_id}
+GET /oauth2/register/{client_id}
 Authorization: Bearer <registration_access_token>
 Content-Type: application/json
 
@@ -111,6 +111,6 @@ The `DELETE` endpoint requires the client to authenticate with the `registration
 `token_endpoint_auth_method`. It can be used to delete the OAuth2 Client.
 
 ```
-DELETE /openid/register/{client_id}
+DELETE /oauth2/register/{client_id}
 Authorization: Bearer <registration_access_token>
 ```


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

The dynamic client registration endpoint was specified at /openid/register, but Ory Hydra exposes it at /oauth2/register.

## Related Issue or Design Document
Ory Hydra OpenAPI specification was fixed in this PR: https://github.com/ory/hydra/pull/3141

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments
Will sign the CLA once clarified with my superior.
