### PR TITLE
feat: use context in Go example middleware

### DIFF
--- a/code-examples/protect-page-login/go/handler.go
+++ b/code-examples/protect-page-login/go/handler.go
@@ -13,7 +13,7 @@ func (app *App) dashboardHandler() http.HandlerFunc {
 			http.Error(writer, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		session, err := json.Marshal(app.session)
+		session, err := json.Marshal(getSession(request.Context()))
 		if err != nil {
 			http.Error(writer, err.Error(), http.StatusInternalServerError)
 			return

--- a/code-examples/protect-page-login/go/main.go
+++ b/code-examples/protect-page-login/go/main.go
@@ -1,45 +1,42 @@
 package main
 
 import (
-  "fmt"
-  ory "github.com/ory/client-go"
-  "net/http"
-  "os"
+	"fmt"
+	"net/http"
+	"os"
+
+	ory "github.com/ory/client-go"
 )
 
 type App struct {
-  ory *ory.APIClient
-  // save the cookies for any upstream calls to the Ory apis
-  cookies string
-  // save the session to display it on the dashboard
-  session *ory.Session
+	ory *ory.APIClient
 }
 
 func main() {
-  proxyPort := os.Getenv("PROXY_PORT")
-  if proxyPort == "" {
-    proxyPort = "4000"
-  }
+	proxyPort := os.Getenv("PROXY_PORT")
+	if proxyPort == "" {
+		proxyPort = "4000"
+	}
 
-  // register a new Ory client with the URL set to the Ory CLI Proxy
-  // we can also read the URL from the env or a config file
-  c := ory.NewConfiguration()
-  c.Servers = ory.ServerConfigurations{{URL: fmt.Sprintf("http://localhost:%s/.ory", proxyPort)}}
+	// register a new Ory client with the URL set to the Ory CLI Proxy
+	// we can also read the URL from the env or a config file
+	c := ory.NewConfiguration()
+	c.Servers = ory.ServerConfigurations{{URL: fmt.Sprintf("http://localhost:%s/.ory", proxyPort)}}
 
-  app := &App{
-    ory: ory.NewAPIClient(c),
-  }
-  mux := http.NewServeMux()
+	app := &App{
+		ory: ory.NewAPIClient(c),
+	}
+	mux := http.NewServeMux()
 
-  // dashboard
-  mux.Handle("/", app.sessionMiddleware(app.dashboardHandler()))
+	// dashboard
+	mux.Handle("/", app.sessionMiddleware(app.dashboardHandler()))
 
-  port := os.Getenv("PORT")
-  if port == "" {
-    port = "3000"
-  }
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
 
-  fmt.Printf("Application launched and running on http://127.0.0.1:%s\n", port)
-  // start the server
-  http.ListenAndServe(":"+port, mux)
+	fmt.Printf("Application launched and running on http://127.0.0.1:%s\n", port)
+	// start the server
+	http.ListenAndServe(":"+port, mux)
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

If a beginner attempts to use the pattern from the code in the Go example middle-ware, they'll see some unexpected issues.
`App` is shared across requests so if more then one request is being processed there is a race condition.
This PR will remove that issue by using just the request's context to pass values around.
