### PR TITLE
clarify logout confirmation paragraph

### DIFF
--- a/docs/hydra/concepts/logout.mdx
+++ b/docs/hydra/concepts/logout.mdx
@@ -94,8 +94,7 @@ The server response is a JSON object with the following keys:
 }
 ```
 
-Next, the logout provider should decide if the end-user should perform a UI action such as confirming the logout request. It's
-RECOMMENDED to request logout confirmation from the end-user when `rp_initiated` is set to true.
+Next, the logout provider should decide if the end-user should perform a UI action such as confirming the logout request. It's STRONGLY RECOMMENDED to request logout confirmation from the end-user when `rp_initiated` is set to `false` as this signifies that the end-user requested the logout without any further query parameters. In this situation neither Ory Hydra nor the logout provider can implicitly verify whether the end-user willingly requested the logout URL or if they were tricked into clicking a manipulated link in a vulnerable application. On the other hand, when `rp_initiated` is set to `true` it's also RECOMMENDED to request logout confirmation from the end-user, however, based on your Relying Parties (the OAuth2 Clients) this step could most likely safely be skipped.
 
 When the logout provider decides to accept the logout request, the flow is completed as follows:
 


### PR DESCRIPTION

## Related Issue or Design Document

relates to https://github.com/ory/hydra/issues/3171

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

As discussed in https://github.com/ory/hydra/issues/3171 the current documentation concerning the logout flow in Ory Hydra had no clear wording on how logout confirmation should be handled in case of an OP initiated logout. Requiring no end-user logout confirmation in this scenario may allow attackers to force unwanted logouts if they can trick end-users into going to `https://hydra/oauth2/sessions/logout`. Therefore, logout confirmation is strongly recommended.