### PR TITLE
fix: missing user.read scope for `https://graph.microsoft.com/v1.0/me`.

### DIFF
--- a/docs/guides/social-signin/microsoft.mdx
+++ b/docs/guides/social-signin/microsoft.mdx
@@ -195,11 +195,6 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 By default, Microsoft uses the identifier taken from the `sub` field of OIDC `id_token`. The same identifier is also returned by
 the standard OIDC `/userinfo` endpoint.
 
-However, some systems use the `id` field returned by the `https://graph.microsoft.com/v1.0/me` endpoint as a subject identifier.
-To make migrating such systems to Kratos easier, you can use the identifier from obtained from the `me` endpoint.
-
-To do that, add the `subject_source` field set to `me` to the social sign-in provider config for your Kratos instance.
-
 ```yaml title=kratos-config.yaml
   providers:
   - id: microsoft # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
@@ -216,6 +211,16 @@ To do that, add the `subject_source` field set to `me` to the social sign-in pro
     scope:
     - profile
     - email
+```
+
+However, some systems use the `id` field returned by the `https://graph.microsoft.com/v1.0/me` endpoint as a subject identifier.
+To make migrating such systems to Kratos easier, you can use the identifier obtained from the `me` endpoint. To do that, update 
+the social sign-in provider config of your Kratos instance with the following.
+
+```yaml
+subject_source: me
+scope:
+  - https://graph.microsoft.com/User.Read
 ```
 
 ## Prevent having to login after sign-up


### PR DESCRIPTION
When using `subject_source: me`, the delegated app also needs `User.Read` or higher permissions, please see [MS docs](https://docs.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http#permissions).

I've also refactored that section a bit, to have separated recommended, sensible defaults and extensions / variants paragraphs. 

## Related Issue or Design Document

How I stumbled upon this.
- https://github.com/ory/kratos/pull/2647.

Historical Issues and PRs

- https://github.com/ory/kratos/issues/2150
- https://github.com/ory/kratos/pull/2153
- https://github.com/ory/docs/pull/706

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

Note: It's still a bit ambiguous that MS's recommendation is to use the `userinfo` endpoint and `sub` field while the default example shows the `me` endpoint. I haven't changed that yet as it has been reviewed but would love some feedback on it either here or on Slack about what is Ory's recommendation as I could see pros and cons on both sides.
