### PR TITLE
docs: explain insecure Keto CLI flag

### DIFF
--- a/docs/keto/guides/expand-api-display-who-has-access.mdx
+++ b/docs/keto/guides/expand-api-display-who-has-access.mdx
@@ -59,7 +59,14 @@ directories:/photos#parent@(files:/photos/mountains.jpg#_)
 ```
 
 The user `maureen` now wants to manage `access` for the file `/photos/beach.jpg`. Therefore, the application uses the expand-API
-to get a tree of everyone who has access to that file:
+to get a tree of everyone who has access to that file.
+
+:::note
+
+You must use the flag `--insecure-disable-transport-security` with version v0.9.0 or newer of the Keto CLI if you run Keto without
+TLS.
+
+:::
 
 <CodeTabs sampleId="expand-api-display-access/01-expand-beach" version="v0.7.0-alpha.1" />
 

--- a/docs/keto/guides/list-api-display-objects.mdx
+++ b/docs/keto/guides/list-api-display-objects.mdx
@@ -63,7 +63,14 @@ chats:coffee-break#member@Julia
 chats:coffee-break#member@Patrik
 ```
 
-The user `PM` now opens the chat application. To display a list of all of `PM`'s chats, the application uses Keto's list API:
+The user `PM` now opens the chat application. To display a list of all of `PM`'s chats, the application uses Keto's list API.
+
+:::note
+
+You must use the flag `--insecure-disable-transport-security` with version v0.9.0 or newer of the Keto CLI if you run Keto without
+TLS.
+
+:::
 
 <CodeTabs sampleId="list-api-display-objects/01-list-PM" version="v0.7.0-alpha.1" />
 

--- a/docs/keto/guides/simple-access-check-guide.mdx
+++ b/docs/keto/guides/simple-access-check-guide.mdx
@@ -62,7 +62,8 @@ that the known cypher messages are stored in Ory Keto and access to the cleartex
 Ory Keto can know the exact relation tuple that the application is checking. Intuitively, this means that `john` was allowed to
 `decypher` the message `02y_15_4w350m3` directly (imagine a "Share with `john`" input in a UI).
 
-Try this yourself by first adding the relation tuple using the [write API](../concepts/api-overview.mdx#write-apis):
+Try this yourself by first adding the relation tuple using the [write API](../concepts/api-overview.mdx#write-apis) (note that the
+flag `--insecure-disable-transport-security` is necessary with newer versions of the Keto CLI if you run Keto without TLS):
 
 <CodeTabs sampleId="simple-access-check-guide/00-write-direct-access" version="v0.7.0-alpha.1" />
 


### PR DESCRIPTION
This PR quickly explains the usage of the new --insecure flags in the Keto CLI.

Blocked by https://github.com/ory/keto/pull/991