### PR TITLE
docs: move nextjs example

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -21,11 +21,11 @@ module.exports = {
                 "getting-started/integrate-auth/go",
                 "getting-started/integrate-auth/php",
                 "getting-started/integrate-auth/expressjs",
+                "getting-started/integrate-auth/nextjs",
               ],
             },
             {
               "Single Page App (SPA)": [
-                "getting-started/integrate-auth/nextjs",
                 "getting-started/integrate-auth/flutter-web-redirect",
                 "getting-started/integrate-auth/react",
                 "getting-started/integrate-auth/vue",


### PR DESCRIPTION
I got some feedback that the NextJs example would be more fitting in the SSA category than SPA. 
(also see [auth0 examples](https://auth0.com/docs/quickstarts))

Another thing was that Flutter should also be under native/mobile, but I was not sure since the example seems to be for Flutter Web, which is not used for mobile/native?

Maybe we should rename it to Flutter Web in the sidebar if its not usable for mobile/native dev