### PR TITLE
docs: fix "log in" and "log out" as verbs

### DIFF
--- a/docs/hydra/advanced.md
+++ b/docs/hydra/advanced.md
@@ -204,15 +204,15 @@ setting `force_subject_identifier` when accepting the login challenge in your us
 
 ### Using login_hint with different subject
 
-When a user already logged in with a subject(for example user-A), and she would like to login as another user using login_hint(for
-example login_hint=user-B), directly accepting the latter login request in your login provider will make hydra reply:
-`Subject from payload doesn't match subject from previous authentication`
+When a user already logged in with a subject(for example user-A), and she would like to log in as another user using
+login_hint(for example login_hint=user-B), directly accepting the latter login request in your login provider will make hydra
+reply: `Subject from payload doesn't match subject from previous authentication`
 
 The suggested flow is:
 
 Check the response from [GET login request](reference/api.mdx#get-a-login-request), if both the `subject` and `login_hint` are NOT
 empty and also NOT the same user, redirect UserAgent to `request_url` which is appended with '?prompt=login'. This will make hydra
-ignore the existing authentication, and allow your login provider to login a different subject.
+ignore the existing authentication, and allow your login provider to log in a different subject.
 
 For more information on `prompt=login` and other options, please check
 [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).

--- a/docs/hydra/guides/gitlab.mdx
+++ b/docs/hydra/guides/gitlab.mdx
@@ -49,12 +49,12 @@ docker-compose -f quickstart.yml \
     up --build
 ```
 
-After this succeeds, you can access the login page [sign-in-page](http://localhost:8000/users/sign_in). Don't try to login, yet,
-we have to create the client in Ory Hydra, first.
+After this succeeds, you can access the login page [sign-in-page](http://localhost:8000/users/sign_in). Don't try to log in yet.
+We have to create the client in Ory Hydra first.
 
 ## Creating the client in Ory Hydra
 
-Depending on whether you've the hydra-binary available, you can use it directly or the one in the docker-container.
+Depending on whether you have the hydra-binary available, you can use it directly or the one in the docker-container.
 
 ```sh
 hydra clients create \
@@ -322,7 +322,7 @@ application been monkey-patched while following this guide (so far).
 
 ### Client wrong
 
-After trying to login you get a message like this:
+After trying to log in, you get a message like this:
 
 > Error: invalid_client Description: Client authentication failed (for example, unknown client, no client authentication included,
 > or unsupported authentication method) Hint: The requested OAuth 2.0 Client doesn't exist.

--- a/docs/kratos/_common/oidc_session_hook.mdx
+++ b/docs/kratos/_common/oidc_session_hook.mdx
@@ -1,5 +1,5 @@
 When adding social sign-in providers manually, remember to add the `session` hook to `after/oidc/hooks`. If you don't add this
-hook, users will have to login again after signing up to get a session.
+hook, users will have to log in again after signing up to get a session.
 
 ```yaml
 selfservice:

--- a/docs/kratos/manage-identities/05_identity-schema.mdx
+++ b/docs/kratos/manage-identities/05_identity-schema.mdx
@@ -237,7 +237,7 @@ Let's extend the Identity Schema from the previous chapter with a phone number:
           "type": "string",
           "format": "tel",
 
-          // The phone number is marked as an identifier. This allows the user to login with both email and phone number.
+          // The phone number is marked as an identifier. This allows the user to log in with both email and phone number.
           "ory.sh/kratos": {
             "credentials": {
               "password": {

--- a/docs/kratos/self-service/flows/user-logout.mdx
+++ b/docs/kratos/self-service/flows/user-logout.mdx
@@ -92,7 +92,7 @@ curl -s --cookie $cookieJar --cookie-jar $cookieJar -H "Accept: application/json
   jq -r ".id"
 ```
 
-To logout, first get the generated Logout URL then point the Browser to it:
+To log out, first get the generated Logout URL then point the Browser to it:
 
 ```shell
 # Get the Logout URL

--- a/docs/kratos/social-signin/01_overview.mdx
+++ b/docs/kratos/social-signin/01_overview.mdx
@@ -88,7 +88,7 @@ Since it constitutes a security threat, automatic account linking is not availab
 
 :::
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/10_google.mdx
+++ b/docs/kratos/social-signin/10_google.mdx
@@ -187,7 +187,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/15_facebook.mdx
+++ b/docs/kratos/social-signin/15_facebook.mdx
@@ -163,7 +163,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/20_microsoft.mdx
+++ b/docs/kratos/social-signin/20_microsoft.mdx
@@ -222,7 +222,7 @@ To do that, add the `subject_source` field set to `me` to the social sign-in pro
     - email
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/25_github.mdx
+++ b/docs/kratos/social-signin/25_github.mdx
@@ -168,7 +168,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -114,7 +114,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -116,7 +116,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -120,7 +120,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -108,7 +108,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -110,7 +110,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -137,7 +137,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/60_twitch.mdx
+++ b/docs/kratos/social-signin/60_twitch.mdx
@@ -125,7 +125,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -130,7 +130,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/70_yandex.mdx
+++ b/docs/kratos/social-signin/70_yandex.mdx
@@ -108,7 +108,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/75_vk.mdx
+++ b/docs/kratos/social-signin/75_vk.mdx
@@ -109,7 +109,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'

--- a/docs/kratos/social-signin/80_dingtalk.mdx
+++ b/docs/kratos/social-signin/80_dingtalk.mdx
@@ -113,7 +113,7 @@ import ConfigAsEnv from '../_common/config_as_env.mdx'
 <ConfigAsEnv />
 ```
 
-## Prevent having to login after sign-up
+## Prevent having to log in after sign-up
 
 ```mdx-code-block
 import OidcSessionHook from '../_common/oidc_session_hook.mdx'


### PR DESCRIPTION
"log in" and "log out" are verbs, and "login" and "logout" are nouns in English. Previously the docs used "login" and "logout" as verbs. I also fixed a couple minor issues that I noticed while making these corrections.