### PR TITLE
docs: update incorrect information about courier templates

### DIFF
--- a/docs/kratos/emails-sms/05_custom-email-templates.mdx
+++ b/docs/kratos/emails-sms/05_custom-email-templates.mdx
@@ -89,7 +89,7 @@ The `plaintext` and `html` fields are mandatory when defining the `body` key. Al
 the custom templates, it falls back to the built-in templates or to the `template_override_path` (if specified).
 
 ```yaml title=path/to/kratos/config.yml
-smtp:
+courier:
   template_override_path: /conf/courier-template
   # ...
   templates:


### PR DESCRIPTION
According to the documentation the templates should be defined in `courier` and not `smtp`.  After testing this locally this also seems the case.

With `smtp`:
config:
```
smtp:
  templates:
    recovery:
      valid:
        email:
          body: 
            html: file:///etc/kratos/templates/recovery/valid/email.body.gotmpl
            plaintext: file:///etc/kratos/templates/recovery/valid/email.body.plaintext.gotmpl
          subject: file:///etc/kratos/templates/recovery/valid/email.subject.gotmpl
``` 
![kratos_smtp_root](https://user-images.githubusercontent.com/22589095/194330107-3137257c-24c6-48ff-a2dc-0c52a74f83c7.png)

With the correct `courier`:
config:
```
courier:
  ...
  templates:
    recovery:
      valid:
        email:
          body: 
            html: file:///etc/kratos/templates/recovery/valid/email.body.gotmpl
            plaintext: file:///etc/kratos/templates/recovery/valid/email.body.plaintext.gotmpl
          subject: file:///etc/kratos/templates/recovery/valid/email.subject.gotmpl
``` 
![Kratos_courier_root](https://user-images.githubusercontent.com/22589095/194330538-5c66f000-414b-4894-bf5e-01b825017b25.png)




- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
