### PR TITLE
fix: update keto prod guide

### DIFF
--- a/docs/hydra/production.md
+++ b/docs/hydra/production.md
@@ -3,7 +3,10 @@ id: production
 title: Prepare for production
 ---
 
-This document summarizes some considerations you will find useful when preparing for production.
+Read this document to prepare for production when self-hosting Ory Hydra.  
+Feel free to open a pull request when you have an idea how to improve this documentation.
+
+Read more about [deployment fundamentals and requirements for Ory](https://www.ory.sh/docs/ecosystem/deployment).
 
 ## Ory Hydra behind an API gateway
 
@@ -40,8 +43,8 @@ that we discourage you from doing so and that you should know what you're doing.
 ### Routing
 
 It's common to use a router, or API gateway, to route subdomains or paths to a specific service. For example,
-`https://myservice.com/hydra/` is routed to `http://10.0.1.213:3912/` where `10.0.1.213` is the host running ORY Hydra. To compute
-the values for the consent challenge, ORY Hydra uses the host and path headers from the HTTP request. Therefore, it's important to
+`https://myservice.com/hydra/` is routed to `http://10.0.1.213:3912/` where `10.0.1.213` is the host running Ory Hydra. To compute
+the values for the consent challenge, Ory Hydra uses the host and path headers from the HTTP request. Therefore, it's important to
 set up your API Gateway in such a way, that it passes the public host (in this case `myservice.com`) and the path without any
 prefix (in this case `hydra/`). If you use the Mashape Kong API gateway, you can achieve this by setting `strip_request_path=true`
 and `preserve_host=true.`
@@ -83,7 +86,7 @@ The Token Introspection endpoint requires authentication. But since there is no 
 the endpoint to be used. If you need to access this endpoint in production, you should configure your API Gateway or Application
 Proxy to restrict which clients have access to the endpoint.
 
-We generally advise to run ORY Hydra with `hydra serve all` which listens on both ports in one process.
+We generally advise to run Ory Hydra with `hydra serve all` which listens on both ports in one process.
 
 ### Binding to different interfaces or UNIX sockets
 
@@ -95,7 +98,7 @@ specified as TCP address or as UNIX socket (giving the absolute path to the sock
 - `PUBLIC_HOST=127.0.0.1`
 - `ADMIN_HOST="unix:/var/run/hydra/admin_socket"`
 
-ORY Hydra will try to create the socket file during startup and the socket will be writeable by the user running ORY Hydra. The
+Ory Hydra will try to create the socket file during startup and the socket will be writeable by the user running Ory Hydra. The
 owner, group and mode of the socket can be modified:
 
 ```yaml

--- a/docs/keto/guides/production.md
+++ b/docs/keto/guides/production.md
@@ -11,13 +11,14 @@ Feel free to open a pull request when you have an idea how to improve this docum
 Ory Keto requires a production-grade database such as PostgreSQL, MySQL, CockroachDB. Don't use SQLite in production! Read more
 about [deployment fundamentals and requirements for Ory](https://www.ory.sh/docs/ecosystem/deployment).
 
-## Ory Keto Write API behind an API gateway
+## Ory Keto API behind an API gateway
 
 Although Ory Keto implements all Go best practices around running public-facing production HTTP servers, we discourage running Ory
 Keto facing the public net directly. We strongly recommend running Ory Keto behind an API gateway or a load balancer. It's common
 to terminate TLS on the edge (gateway / load balancer) and use certificates provided by your infrastructure provider such as AWS
-CA for last mile security. A good practice is to not expose the Write API at all to the public internet and use a Zero Trust
-networking architecture within your intranet.
+CA for last mile security. A good practice is to not expose the Write API at all to the public internet. The Read API should also
+be protected, depending on your usecase it can reveal expose information (for example leak who has permission to do something).
+Use a Zero Trust networking architecture within your intranet.
 
 ## Scaling
 

--- a/docs/keto/guides/production.md
+++ b/docs/keto/guides/production.md
@@ -1,23 +1,24 @@
 ---
 id: production
-title: Going to production
+title: Prepare for production
 ---
 
-:::warning
-
-This document is still in development.
-
-:::
+Read this document to prepare for production when self-hosting Ory Keto.  
+Feel free to open a pull request when you have an idea how to improve this documentation.
 
 ## Database
 
-Ory Keto requires a production-grade database such as PostgreSQL, MySQL, CockroachDB. Don't use SQLite in production!
+Ory Keto requires a production-grade database such as PostgreSQL, MySQL, CockroachDB. Don't use SQLite in production! Read more
+about [deployment fundamentals and requirements for Ory](https://www.ory.sh/docs/ecosystem/deployment).
 
-### Write API
+## Ory Keto Write API behind an API gateway
 
-Never expose the Ory Keto Write API to the internet unsecured. Always require authorization. A good practice is to not expose the
-Write API at all to the public internet and use a Zero Trust Networking Architecture within your intranet.
+Although Ory Keto implements all Go best practices around running public-facing production HTTP servers, we discourage running Ory
+Keto facing the public net directly. We strongly recommend running Ory Keto behind an API gateway or a load balancer. It's common
+to terminate TLS on the edge (gateway / load balancer) and use certificates provided by your infrastructure provider such as AWS
+CA for last mile security. A good practice is to not expose the Write API at all to the public internet and use a Zero Trust
+networking architecture within your intranet.
 
 ## Scaling
 
-There are no additional requirements for scaling Ory Keto, just spin up another container!
+There are no additional requirements for scaling when self-hosting Ory Keto, just spin up another container!


### PR DESCRIPTION
Updates the current "prod" guide for Keto to a "prepare for production" guide as we have in Hydra, with a similar structure - this should stop the bleeding until we create a proper "selfhosted" section for Keto. 

Also a few stylistic changes in the Hydra guide.