### PR TITLE
chore: add email address for bounty program access

### DIFF
--- a/docs/ecosystem/security.md
+++ b/docs/ecosystem/security.md
@@ -6,8 +6,8 @@ title: Security policy
 :::info Private Bug Bounty Program
 
 Ory is working with Hackerone to provide a private bug bounty program for all Ory products. If you are interested in joining the
-program, please [create an account at Hackerone](https://hackerone.com/sign_up) and
-[request access](mailto:security@ory.sh). The following is the policy for the private bug bounty program.
+program, please [create an account at Hackerone](https://hackerone.com/sign_up) and [request access](mailto:security@ory.sh). The
+following is the policy for the private bug bounty program.
 
 :::
 

--- a/docs/ecosystem/security.md
+++ b/docs/ecosystem/security.md
@@ -7,7 +7,7 @@ title: Security policy
 
 Ory is working with Hackerone to provide a private bug bounty program for all Ory products. If you are interested in joining the
 program, please [create an account at Hackerone](https://hackerone.com/sign_up) and
-[request access](https://hackerone.com/ory_corp). The following is the policy for the private bug bounty program.
+[request access](mailto:security@ory.sh). The following is the policy for the private bug bounty program.
 
 :::
 


### PR DESCRIPTION
This pull request removes a link to the HackerOne bounty program that was 404'ing and replaces it with a link to the email address where someone could request access to the bounty program. 


## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
