### PR TITLE
docs: updated scopes for google sidp

### DIFF
--- a/docs/kratos/social-signin/10_google.mdx
+++ b/docs/kratos/social-signin/10_google.mdx
@@ -57,7 +57,7 @@ The Scopes section allows you to define the OAuth scopes Ory requests from the s
 interact with the provider's APIs on behalf of the user, or to access additional user data, which is exposed as claims for data
 mapping.
 
-For Google, add the `email`, `email_verified`, `given_name`, and `family_name` scopes for a basic setup.
+For Google, add the `email` and `profile` scopes for a basic setup.
 
 To learn more about the scopes available for Google, read the
 [related documentation](https://developers.google.com/identity/protocols/oauth2/scopes).


### PR DESCRIPTION
This PR updates the needed scopes for using Google as Social IDP.

## Related Issue or Design Document


## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

As suggested by the old version of the docs, the scopes are invalid:
![Screenshot from 2022-11-29 12-01-11](https://user-images.githubusercontent.com/45126872/204513271-ea898673-7503-485e-a961-977a90b2f5cb.png)
![Screenshot from 2022-11-29 12-01-28](https://user-images.githubusercontent.com/45126872/204513268-9e291744-4b01-4090-8a69-1f878ac7aa02.png)

Changing them to profile works:
![Screenshot from 2022-11-29 12-00-28](https://user-images.githubusercontent.com/45126872/204513274-206b0c53-3d20-4cee-94ff-5d51d14ebaee.png)
![Screenshot from 2022-11-29 12-01-47](https://user-images.githubusercontent.com/45126872/204513264-93bacc66-2e28-461b-a9eb-aa056e4e20b5.png)
![Screenshot from 2022-11-29 12-02-29](https://user-images.githubusercontent.com/45126872/204513258-8facb13d-2676-4724-be5d-43e69bcecde2.png)







