### PR TITLE
add missing 's'

### DIFF
--- a/docs/kratos/emails-sms/10_sending-sms.mdx
+++ b/docs/kratos/emails-sms/10_sending-sms.mdx
@@ -32,7 +32,7 @@ courier:
       url: https://api.twilio.com/2010-04-01/Accounts/YourAccountID/Messages.json
       method: POST
       body: file://./twilio.request.jsonnet
-      header:
+      headers:
         "Content-Type": "application/x-www-form-urlencoded"
       auth:
         type: basic_auth


### PR DESCRIPTION
I got an error in kratos (v0.11.0)
```
kratos I[#/courier/sms/request_config] S[#/properties/courier/properties/sms/properties/
request_config/additionalProperties] additionalProperties "header" not allowed
```

## Related Issue or Design Document
I looked in the schema https://github.com/ory/kratos/blob/master/.schemastore/config.schema.json and fixed the problem by adding an 's'.
This is a minor adaptation to the docs, but they are not correct right now.

## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments
