### PR TITLE
hydra: correct userinfo endpoint docs: sub is not really email address

### DIFF
--- a/docs/hydra/concepts/openid-connect-oidc.mdx
+++ b/docs/hydra/concepts/openid-connect-oidc.mdx
@@ -60,7 +60,7 @@ Authorization: bearer access-token.xxxx
 
 {
  "acr": "oauth2",
- "sub": "xxx@xxx.com"
+ "sub": "04d75756-xxxx-4xxx-9xxx-xxxxxxxxxxxx"
 }
 ```
 
@@ -95,7 +95,7 @@ Authorization: bearer new-access-token.xxxx
 
 {
  "acr": "oauth2",
- "sub": "xxx@xxx.com",
+ "sub": "04d75756-xxxx-4xxx-9xxx-xxxxxxxxxxxx"
  "foo": "bar"
 }
 ```


### PR DESCRIPTION
If I look at the response from the `/userinfo`, the `sub` value is not the email address but the UUID from the database. This can be really confusing, if you want to implement SSO and search for the email address in the response, but it won't be there, even though the documentation states otherwise. Please merge, to not confuse at this point any longer.

## Related Issue or Design Document

-

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

-
