### PR TITLE
docs: refresh session lifespan, extend samples

### DIFF
--- a/code-examples/sdk/go/selfservice/whoami.go
+++ b/code-examples/sdk/go/selfservice/whoami.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+  "context"
+  "fmt"
+  "github.com/ory/client-go"
+  "os"
+)
+
+func init() {
+  cfg := client.NewConfiguration()
+  cfg.Servers = client.ServerConfigurations{
+    {URL: fmt.Sprintf("https://%s.projects.oryapis.com", os.Getenv("ORY_PROJECT_SLUG"))},
+  }
+
+  ory = client.NewAPIClient(cfg)
+}
+
+func CheckSession(ctx context.Context, sessionToken string) (session *client.Session, err error) {
+  // highlight-start
+  session, _, err = ory.FrontendApi.ToSession(ctx).
+    XSessionToken(sessionToken).
+    Execute()
+  // highlight-end
+
+  if err != nil {
+    // error revoking the session, for example due to expired token provided
+    return nil, err
+  }
+
+  return session, nil
+}

--- a/code-examples/sdk/go/session/refresh-session.go
+++ b/code-examples/sdk/go/session/refresh-session.go
@@ -1,0 +1,19 @@
+package session
+
+import (
+	"context"
+	"github.com/ory/client-go"
+)
+
+func RefreshSession(ctx context.Context, sessionId string) (session *client.Session, err error) {
+	// highlight-start
+	session, _, err = ory.IdentityApi.ExtendSession(ContextWithToken(ctx), sessionId).
+		Execute()
+	// highlight-end
+
+	if err != nil {
+		return nil, err
+	}
+
+	return session, err
+}

--- a/code-examples/sdk/typescript/src/selfservice/session/whoami-native.ts
+++ b/code-examples/sdk/typescript/src/selfservice/session/whoami-native.ts
@@ -1,0 +1,15 @@
+import { Configuration, FrontendApi } from "@ory/client"
+
+const frontend = new FrontendApi(
+  new Configuration({
+    basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
+  }),
+)
+
+export async function checkSession(sessionId: string, token: string) {
+  // highlight-start
+  return await frontend.toSession({
+    xSessionToken: token,
+  })
+  // highlight-end
+}

--- a/code-examples/sdk/typescript/src/selfservice/session/whoami-react.tsx
+++ b/code-examples/sdk/typescript/src/selfservice/session/whoami-react.tsx
@@ -1,0 +1,48 @@
+import { Configuration, FrontendApi, Session } from "@ory/client"
+import { useState } from "react"
+
+const ory = new FrontendApi(
+  new Configuration({
+    basePath: "http://localhost:4000", // Use your local Ory Tunnel URL
+    baseOptions: {
+      withCredentials: true,
+    },
+  }),
+)
+
+// Example of a modal component
+export function CheckSession() {
+  const [session, setSession] = useState<Session>(undefined)
+
+  // highlight-start
+  const handleCheckSession = async () => {
+    try {
+      const result = await ory.toSession()
+      setSession(result.data)
+    } catch (error) {
+      // The session could not be fetched
+      // This might occur if the current session has expired
+    }
+  }
+  // highlight-end
+
+  return (
+    <>
+      <button onClick={handleCheckSession}>Get my Session payload</button>
+      {session && (
+        <table>
+          <tr>
+            <th>Session ID</th>
+            <th>Expires at</th>
+            <th>Authenticated at</th>
+          </tr>
+          <tr id={session.id}>
+            <td>{session.id}</td>
+            <td>{session.expires_at || ""}</td>
+            <td>{session.authenticated_at || ""}</td>
+          </tr>
+        </table>
+      )}
+    </>
+  )
+}

--- a/code-examples/sdk/typescript/src/session/delete-sessions-native.ts
+++ b/code-examples/sdk/typescript/src/session/delete-sessions-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/code-examples/sdk/typescript/src/session/disable-session-native.ts
+++ b/code-examples/sdk/typescript/src/session/disable-session-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/code-examples/sdk/typescript/src/session/get-identity-sessions-native.ts
+++ b/code-examples/sdk/typescript/src/session/get-identity-sessions-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/code-examples/sdk/typescript/src/session/get-session-native.ts
+++ b/code-examples/sdk/typescript/src/session/get-session-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/code-examples/sdk/typescript/src/session/get-sessions-native.ts
+++ b/code-examples/sdk/typescript/src/session/get-sessions-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/code-examples/sdk/typescript/src/session/init-client-native.ts
+++ b/code-examples/sdk/typescript/src/session/init-client-native.ts
@@ -3,6 +3,6 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )

--- a/code-examples/sdk/typescript/src/session/refresh-session-native.ts
+++ b/code-examples/sdk/typescript/src/session/refresh-session-native.ts
@@ -1,0 +1,16 @@
+import { Configuration, IdentityApi } from "@ory/client"
+
+const identityApi = new IdentityApi(
+  new Configuration({
+    basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
+    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+  }),
+)
+
+export async function RefreshSession(sessionId: string) {
+  // highlight-start
+  return await identityApi.extendSession({
+    id: sessionId,
+  })
+  // highlight-end
+}

--- a/code-examples/sdk/typescript/src/session/refresh-session-native.ts
+++ b/code-examples/sdk/typescript/src/session/refresh-session-native.ts
@@ -3,7 +3,7 @@ import { Configuration, IdentityApi } from "@ory/client"
 const identityApi = new IdentityApi(
   new Configuration({
     basePath: `https://${process.env.ORY_PROJECT_SLUG}.projects.oryapis.com`,
-    apiKey: `${process.env.ORY_ACCESS_TOKEN}`,
+    accessToken: `${process.env.ORY_ACCESS_TOKEN}`,
   }),
 )
 

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -123,8 +123,12 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
 
 ### Using Ory Session Cookie
 
-An Ory Session Cookie is issued when the user signs in through a web browser. To get the session payload, send a request to the
-`/sessions/whoami` endpoint:
+An Ory Session Cookie is issued when the user signs in through the browser based self-service login flow. To get the session payload, send a request to the
+`/sessions/whoami` endpoint.
+
+:::note
+Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of the session tokens.
+:::
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">
@@ -154,6 +158,11 @@ import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/sel
 
 An Ory Session Token is issued when the user authenticates through a client other than a web browser. To get the session payload,
 send a request to the `/sessions/whoami` endpoint.
+
+:::note
+Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser should use session tokens instead of cookies.
+:::
+
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -32,8 +32,7 @@ For security reasons, you can't break the isolation between cookies and session 
 
 ## Ory Session
 
-An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/getSession)
-response.
+An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/getSession) response.
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -121,8 +120,8 @@ This flow is similar to [GitHub's sudo mode](https://help.github.com/en/github/a
 
 :::
 
-The session is considered privileged when its `authenticated_at` is younger than the `privileged_session_max_age` value defined
-in the configuration.
+The session is considered privileged when its `authenticated_at` is younger than the `privileged_session_max_age` value defined in
+the configuration.
 
 ### Configuration
 

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -7,9 +7,7 @@ sidebar_label: Overview
 # Overview
 
 When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
-Session.
-
-The session is a proof that the user is authenticated and allows to interact with the system without the need to authenticate
+Session. The session is proof that the user is authenticated and allows to interact with the system without the need to authenticate
 again for every request.
 
 Sessions can be issued in two formats:
@@ -27,77 +25,15 @@ For security reasons, you can't break the isolation between cookies and session 
 
 ## Ory Session
 
-This is an sample Ory Session:
-
-```json
-{
-  "id": "1338410d-c473-4503-a96a-53efa06e2531",
-  "active": true,
-  "expires_at": "2021-10-15T15:58:57.683338Z",
-  "authenticated_at": "2021-10-14T15:58:57.683338Z",
-  "authenticator_assurance_level": "aal2",
-  "authentication_methods": [
-    {
-      "method": "password",
-      "completed_at": "2021-10-14T15:55:19.03621Z"
-    },
-    {
-      "method": "lookup_secret",
-      "completed_at": "2021-10-14T15:56:21.257867Z"
-    },
-    {
-      "method": "lookup_secret",
-      "completed_at": "2021-10-14T15:58:57.683337Z"
-    },
-    {
-      "method": "lookup_secret",
-      "completed_at": "2021-10-14T16:03:14.833192Z"
-    }
-  ],
-  "issued_at": "2021-10-14T15:58:57.683338Z",
-  "identity": {
-    "id": "9496bbd5-f426-473f-b087-c7df853f274a",
-    "schema_id": "default",
-    "schema_url": "https://<your-project-slug>.projects.oryapis.com/schemas/default",
-    "state": "active",
-    "state_changed_at": "2021-10-14T17:55:17.885497+02:00",
-    "traits": {
-      "website": "https://www.ory.sh/",
-      "email": "0.wz4yhr0zwyd@ory.sh"
-    },
-    "verifiable_addresses": [
-      {
-        "id": "4de14270-ca13-4efb-ac3f-8f03b1f649d8",
-        "value": "0.wz4yhr0zwyd@ory.sh",
-        "verified": false,
-        "via": "email",
-        "status": "sent",
-        "created_at": "2021-10-14T17:55:17.886639+02:00",
-        "updated_at": "2021-10-14T18:03:14.839009+02:00"
-      }
-    ],
-    "recovery_addresses": [
-      {
-        "id": "fdab5a5f-5efc-4202-93b5-fd3ee632420b",
-        "value": "0.wz4yhr0zwyd@ory.sh",
-        "via": "email",
-        "created_at": "2021-10-14T17:55:17.886831+02:00",
-        "updated_at": "2021-10-14T18:03:14.839105+02:00"
-      }
-    ],
-    "created_at": "2021-10-14T17:55:17.886237+02:00",
-    "updated_at": "2021-10-14T17:55:17.886237+02:00"
-  }
-}
-```
+An example of a sample Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/disableSession) response.
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:-------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `active`           | When set to `true`, the Ory Session is active and can be used to authenticate requests.                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `expires_at`       | Defines the time when the Session expires. This value depends on the session lifespan configuration.                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `authenticated_at` | Indicates the time of the most recent successful authentication. This value is updated when: <ul><li>The end-user authenticates with a second factor such as TOTP</li><li>The end-user refreshes their session using the [`/self-service/login/browser`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowForBrowsers) endpoint or [`/self-service/login/api`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowWithoutBrowser) endpoint and setting `refresh` to `true`</li></ul> |
 
-## Ory Session Cookie
+### Using Ory Session Cookie
 
 An Ory Session Cookie is issued when the user signs in through a web browser. To get the session payload, send a request to the
 `/sessions/whoami` endpoint:
@@ -111,7 +47,7 @@ import CodeBlock from '@theme/CodeBlock'
   -H 'Cookie: ory_kratos_session=MTYzNDIyNzEzN3xEdi1CQkFFQ180SUFBUkFCRUFBQVJfLUNBQUVHYzNSeWFXNW5EQThBRFhObGMzTnBiMjVmZEc5clpXNEdjM1J5YVc1bkRDSUFJRTFDYWtvME5VNVlaVWxvYVZWeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cL21Dclk3nCoXV41N6bFxvVJSt7CeICy_815Aw=='`}</CodeBlock>
 ```
 
-## Ory Session Token
+### Using Ory Session Token
 
 An Ory Session Token is issued when the user authenticates through a client other than a web browser. To get the session payload,
 send a request to the `/sessions/whoami` endpoint.

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -121,7 +121,7 @@ This flow is similar to [GitHub's sudo mode](https://help.github.com/en/github/a
 
 :::
 
-The session is considered privileged when its `authenticated_at` isn't older than the `privileged_session_max_age` value defined
+The session is considered privileged when its `authenticated_at` is younger than the `privileged_session_max_age` value defined
 in the configuration.
 
 ### Configuration

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -132,7 +132,7 @@ This is how you update the `privileged_session_max_age` to `15m`:
 <Tabs>
 <TabItem value="console" label="Ory Console" default>
 
-To change the privileged session duration, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 15m30s, 1m) in the Privileged Sessions section and click the **Save** button.
+To change the privileged session duration, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h15m30s, 15m30s, 1m) in the Privileged Sessions section and click the **Save** button.
 
 For example, to set the privileged session duration to 15 minutes, enter `15m`.
 

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -62,9 +62,7 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
       "property1": {
         "config": {},
         "created_at": "2019-08-24T14:15:22Z",
-        "identifiers": [
-          "string"
-        ],
+        "identifiers": ["string"],
         "type": "password",
         "updated_at": "2019-08-24T14:15:22Z",
         "version": 0
@@ -72,9 +70,7 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
       "property2": {
         "config": {},
         "created_at": "2019-08-24T14:15:22Z",
-        "identifiers": [
-          "string"
-        ],
+        "identifiers": ["string"],
         "type": "password",
         "updated_at": "2019-08-24T14:15:22Z",
         "version": 0
@@ -123,12 +119,11 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
 
 ### Using Ory Session Cookie
 
-An Ory Session Cookie is issued when the user signs in through the browser based self-service login flow. To get the session payload, send a request to the
-`/sessions/whoami` endpoint.
+An Ory Session Cookie is issued when the user signs in through the browser based self-service login flow. To get the session
+payload, send a request to the `/sessions/whoami` endpoint.
 
-:::note
-Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of the session tokens.
-:::
+:::note Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of
+the session tokens. :::
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">
@@ -159,10 +154,8 @@ import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/sel
 An Ory Session Token is issued when the user authenticates through a client other than a web browser. To get the session payload,
 send a request to the `/sessions/whoami` endpoint.
 
-:::note
-Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser should use session tokens instead of cookies.
-:::
-
+:::note Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser
+should use session tokens instead of cookies. :::
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -34,6 +34,87 @@ For security reasons, you can't break the isolation between cookies and session 
 
 An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/getSession) response.
 
+```json
+{
+  "active": true,
+  "authenticated_at": "2019-08-24T14:15:22Z",
+  "authentication_methods": [
+    {
+      "aal": "aal0",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "method": "link_recovery"
+    }
+  ],
+  "authenticator_assurance_level": "aal0",
+  "devices": [
+    {
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "ip_address": "string",
+      "location": "string",
+      "user_agent": "string"
+    }
+  ],
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "identity": {
+    "created_at": "2019-08-24T14:15:22Z",
+    "credentials": {
+      "property1": {
+        "config": {},
+        "created_at": "2019-08-24T14:15:22Z",
+        "identifiers": [
+          "string"
+        ],
+        "type": "password",
+        "updated_at": "2019-08-24T14:15:22Z",
+        "version": 0
+      },
+      "property2": {
+        "config": {},
+        "created_at": "2019-08-24T14:15:22Z",
+        "identifiers": [
+          "string"
+        ],
+        "type": "password",
+        "updated_at": "2019-08-24T14:15:22Z",
+        "version": 0
+      }
+    },
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "metadata_admin": {},
+    "metadata_public": {},
+    "recovery_addresses": [
+      {
+        "created_at": "2019-08-24T14:15:22Z",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "updated_at": "2019-08-24T14:15:22Z",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "state": "active",
+    "state_changed_at": "2019-08-24T14:15:22Z",
+    "traits": null,
+    "updated_at": "2019-08-24T14:15:22Z",
+    "verifiable_addresses": [
+      {
+        "created_at": "2014-01-01T23:28:56.782Z",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "status": "string",
+        "updated_at": "2014-01-01T23:28:56.782Z",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  },
+  "issued_at": "2019-08-24T14:15:22Z"
+}
+```
+
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `active`           | When set to `true`, the Ory Session is active and can be used to authenticate requests.                                                                                                                                                                                                                                                                                                                                                                                                                          |

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -7,8 +7,8 @@ sidebar_label: Overview
 # Overview
 
 When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
-Session. The session is proof that the user is authenticated and allows to interact with the system without the need to authenticate
-again for every request.
+Session. The session is proof that the user is authenticated and allows to interact with the system without the need to
+authenticate again for every request.
 
 Sessions can be issued in two formats:
 
@@ -25,10 +25,11 @@ For security reasons, you can't break the isolation between cookies and session 
 
 ## Ory Session
 
-An example of a sample Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/disableSession) response.
+An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/disableSession)
+response.
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-|:-------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `active`           | When set to `true`, the Ory Session is active and can be used to authenticate requests.                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `expires_at`       | Defines the time when the Session expires. This value depends on the session lifespan configuration.                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `authenticated_at` | Indicates the time of the most recent successful authentication. This value is updated when: <ul><li>The end-user authenticates with a second factor such as TOTP</li><li>The end-user refreshes their session using the [`/self-service/login/browser`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowForBrowsers) endpoint or [`/self-service/login/api`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowWithoutBrowser) endpoint and setting `refresh` to `true`</li></ul> |

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -4,14 +4,14 @@ title: Overview of sessions, Ory Session Cookies, and Ory Session Tokens
 sidebar_label: Overview
 ---
 
+# Overview
+
 ```mdx-code-block
 import Tabs from "@theme/Tabs"
 import TabItem from "@theme/TabItem"
 import { getSdkUrl } from '@site/src/hooks'
 import CodeBlock from '@theme/CodeBlock'
 ```
-
-# Overview
 
 When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
 Session. The session is proof that the user is authenticated and allows to interact with the system without the need to

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -122,8 +122,12 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
 An Ory Session Cookie is issued when the user signs in through the browser based self-service login flow. To get the session
 payload, send a request to the `/sessions/whoami` endpoint.
 
-:::note Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of
-the session tokens. :::
+:::note
+
+Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of the
+session tokens.
+
+:::
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">
@@ -154,8 +158,12 @@ import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/sel
 An Ory Session Token is issued when the user authenticates through a client other than a web browser. To get the session payload,
 send a request to the `/sessions/whoami` endpoint.
 
-:::note Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser
-should use session tokens instead of cookies. :::
+:::note
+
+Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser should
+use session tokens instead of cookies.
+
+:::
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">
@@ -220,7 +228,8 @@ For example, to set the privileged session duration to 15 minutes, enter `15m`.
 
   </TabItem>
   <TabItem value="cloud" label="Ory CLI">
-1. Download the Ory Identities config from your project and save it to a file:
+
+1. Download the Ory Identities config from your project and save it to a file.
 
 ```shell
 ## List all available projects
@@ -249,7 +258,7 @@ selfservice:
       required_aal: highest_available
 ```
 
-3. Update the Ory Identities configuration using the file you worked with:
+3. Update the Ory Identities configuration using the file you worked with.
 
 ```shell
  ory update identity-config {project-id} --file identity-config.yaml

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -13,16 +13,15 @@ import { getSdkUrl } from '@site/src/hooks'
 import CodeBlock from '@theme/CodeBlock'
 ```
 
-When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
-Session. The session is proof that the user is authenticated and allows to interact with the system without the need to
-authenticate again for every request.
+When a user authenticates, for example by signing in with their username and password, they receive a session. The session is
+proof that the user is authenticated and allows to interact with the system without the need to re-authenticate for every request.
 
 Sessions can be issued in two formats:
 
-- **Session cookie** - when the system detects that the interaction is done through a web browser, a cookie which represents the
-  user's Session is stored in the browser.
-- **Session token** - when the system detects a client other than a web browser, for example a native mobile app, a Session token
-  is issued to the client.
+- **Ory Session Cookie** - when the system detects that the interaction is performed through a web browser, a cookie which
+  represents the user's session is stored in the browser.
+- **Ory Session Token** - when the system detects that the interaction is performed by a client other than a web browser, for
+  example a native mobile app, a session token is issued to the client.
 
 :::note
 
@@ -30,9 +29,9 @@ For security reasons, you can't break the isolation between cookies and session 
 
 :::
 
-## Ory Session
+## Ory session
 
-An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/getSession) response.
+This is a sample session:
 
 ```json
 {
@@ -119,13 +118,13 @@ An example of an Ory session can be seen in the [Get session API](../../referenc
 
 ### Using Ory Session Cookie
 
-An Ory Session Cookie is issued when the user signs in through the browser based self-service login flow. To get the session
-payload, send a request to the `/sessions/whoami` endpoint.
+An Ory Session Cookie is issued when the user signs in through the browser-based login flow. To get the session payload, send a
+request to the `/sessions/whoami` endpoint.
 
 :::note
 
-Browser based applications including single-page applications(SPAs) and server-side rendered should use cookies instead of the
-session tokens.
+Browser-based applications including single-page applications (SPAs) and server-side rendered apps should use session cookies
+instead of session tokens.
 
 :::
 
@@ -141,7 +140,6 @@ import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/sel
 
 </TabItem>
 <TabItem value="curl" label="cURL">
-
 
 ```mdx-code-block
 <CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
@@ -160,8 +158,8 @@ send a request to the `/sessions/whoami` endpoint.
 
 :::note
 
-Native applications such as desktop and mobile applications, terminal based applications that do not run inside a browser should
-use session tokens instead of cookies.
+Native applications such as desktop applications, mobile applications, or terminal-based apps that do not run inside a browser
+should use session tokens instead of session cookies.
 
 :::
 
@@ -187,142 +185,40 @@ import nativeWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/se
 </TabItem>
 <TabItem value="curl" label="cURL">
 
-
-  ```mdx-code-block
-  <CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
-    -H 'Accept: application/json' \\
-    -H 'Authorization: Bearer BRFbGMzTnBiMjVmZEcEdjM1J5YVc1bkRDSUFvME5VNVlaVeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cLXV41N6bFxvVJSt7CeICy'`}</CodeBlock>
-  ```
+```mdx-code-block
+<CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
+   -H 'Accept: application/json' \\
+   -H 'Authorization: Bearer BRFbGMzTnBiMjVmZEcEdjM1J5YVc1bkRDSUFvME5VNVlaVeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cLXV41N6bFxvVJSt7CeICy'`}</CodeBlock>
+```
 
 </TabItem>
 </Tabs>
 ````
 
-## Privileged Sessions
-
-import { privilegedVideo } from "../../kratos/self-service/flows/code/settings"
-
-To perform some profile changes, such as updating the email address, password, or adding/removing 2FA, the user must have a
-privileged session.
-
-:::tip
-
-This flow is similar to [GitHub's sudo mode](https://help.github.com/en/github/authenticating-to-github/sudo-mode).
-
-:::
-
-The session is considered privileged when its `authenticated_at` is younger than the `privileged_session_max_age` value defined in
-the configuration.
-
-### Configuration
-
-This is how you update the `privileged_session_max_age` to `15m`:
-
-````mdx-code-block
-<Tabs>
-<TabItem value="console" label="Ory Console" default>
-
-To change the privileged session duration, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h15m30s, 15m30s, 1m) in the Privileged Sessions section and click the **Save** button.
-
-For example, to set the privileged session duration to 15 minutes, enter `15m`.
-
-  </TabItem>
-  <TabItem value="cloud" label="Ory CLI">
-
-1. Download the Ory Identities config from your project and save it to a file.
-
-```shell
-## List all available projects
-ory list projects
-
-## Get config
-ory get identity-config {project-id} --format yaml > identity-config.yaml
-```
-
-2. Update the configuration value for privileged session max age property (`privileged_session_max_age`) to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 15m30s, 1m).
-
-```yaml title="config.yml"
-selfservice:
-  flows:
-    settings:
-      after:
-        hooks: []
-        password:
-          hooks: []
-        profile:
-          hooks: []
-      ui_url: /ui/settings
-      // highlight-start
-      privileged_session_max_age: 15m
-      // highlight-end
-      required_aal: highest_available
-```
-
-3. Update the Ory Identities configuration using the file you worked with.
-
-```shell
- ory update identity-config {project-id} --file identity-config.yaml
-```
-
-  </TabItem>
-</Tabs>
-````
-
-With this configuration in place, the user can perform the actions that require a privileged session up to 15 minutes after
-signing in. When this time passes, the user must re-authenticate to access these options.
-
-### Demo
-
-Watch this video to see the flow in action:
-
-<video controls width="100%">
-  <source src={privilegedVideo.webm} type="video/webm" />
-  <source src={privilegedVideo.mp4} type="video/mp4" />
-  Sorry, your browser doesn't support embedded videos.
-</video>
-
-## Refreshing sessions
-
-You can prompt the user to re-authenticate by interacting with the
-[`/self-service/login/browser`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowForBrowsers) or
-[`/self-service/login/api`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowWithoutBrowser) API and setting the
-`refresh` parameter to true. Once the user has re-authenticated, the `authenticated_at` timestamp of the Ory Session will be set
-to the current time.
-
-```mdx-code-block
-<CodeBlock language="shell">{`${getSdkUrl().url}/self-service/login/browser?refresh=true`}</CodeBlock>
-```
-
-If enabled, you can also refresh the second factor by setting both `refresh` and `aal`:
-
-```mdx-code-block
-<CodeBlock language="shell">{`${getSdkUrl().url}/self-service/login/browser?refresh=true&aal=aal2`}</CodeBlock>
-```
-
 ## JSON Web Token (JWT) support
 
 :::warning
 
-Ory doesn't issue Sessions as JSON Web Tokens (JWTs).
+Ory doesn't issue sessions as JSON Web Tokens (JWTs).
 
 :::
 
 Sessions are not issued as JWTs for two main reasons:
 
-1. Ory Sessions can end at any point in time, indicating that the user is no longer signed in. With JWTs it would not easily be
-   possible to determine whether a session is still valid before the token expires.
-2. Ory Sessions can be updated and changed at any point in time (for example when the user updates their profile), which can't be
-   easily reflected in a JWT before it is refreshed.
+1. Sessions can end at any point in time, indicating that the user is no longer signed in. With JWTs, it's difficult to determine
+   if a session is still valid before the token expires.
+2. Sessions can be updated and changed at any point in time, for example, when the user updates their profile. Such change can't
+   be easily reflected in a JWT before it is refreshed.
 
-We are taking many steps to reduce the latency of `toSession` / `/sessions/whoami` endpoints across the globe for Ory Network, so
-that latency is not an issue for users.
+Ory Network employs a session caching mechanism to reduce the latency for `toSession` / `/sessions/whoami` endpoint calls across
+the globe so that latency is not an issue for users. [Read more about session caching.](../../concepts/cache.mdx)
 
-However, if you don't want to make repeated calls to `toSession` / `/sessions/whoami`, or you need to use JWTs in your setup, you
-can convert Ory Sessions to JWTs on your entry point. There, you could add caching to further reduce the amount of API calls made.
+If you don't want to make repeated calls to `toSession` / `/sessions/whoami`, or you need to use JWTs in your setup, you can
+convert sessions to JWTs on your entry point. There, you could add caching to further reduce the amount of API calls made.
 
 :::tip
 
-[Ory Oathkeeper](https://www.ory.sh/oathkeeper) is an API Gateway capable of converting Ory Sessions to JWTs.
+[Ory Oathkeeper](https://www.ory.sh/oathkeeper) is an API Gateway capable of converting sessions to JWTs.
 
 :::
 

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Overview
+title: Overview of sessions, Ory Session Cookies, and Ory Session Tokens
 sidebar_label: Overview
 ---
 
@@ -10,6 +10,8 @@ import TabItem from "@theme/TabItem"
 import { getSdkUrl } from '@site/src/hooks'
 import CodeBlock from '@theme/CodeBlock'
 ```
+
+# Overview
 
 When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
 Session. The session is proof that the user is authenticated and allows to interact with the system without the need to

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -32,7 +32,7 @@ For security reasons, you can't break the isolation between cookies and session 
 
 ## Ory Session
 
-An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/disableSession)
+An example of an Ory session can be seen in the [Get session API](../../reference/api#tag/identity/operation/getSession)
 response.
 
 | Property           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -87,6 +87,8 @@ This flow is similar to [GitHub's sudo mode](https://help.github.com/en/github/a
 The session is considered privileged when its `authenticated_at` isn't older than the `privileged_session_max_age` value defined
 in the configuration.
 
+### Configuration
+
 This is how you update the `privileged_session_max_age` to `15m`:
 
 ````mdx-code-block
@@ -94,29 +96,47 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-  <TabItem value="cloud" label="Ory CLI" default>
+<TabItem value="console" label="Ory Console" default>
 
-```shell
-ory patch identity-config <your-project-id> \\
-  --replace '/selfservice/flows/settings/privileged_session_max_age/lifespan="15m"' # 15 minutes
-```
+To change the privileged session duration, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 15m30s, 1m) in the Privileged Sessions section and click the **Save** button.
+
+For example, to set the privileged session duration to 15 minutes, enter `15m`.
 
   </TabItem>
-  <TabItem value="macos" label="Self-Hosted Ory Kratos Config" default>
+  <TabItem value="cloud" label="Ory CLI">
+1. Download the Ory Identities config from your project and save it to a file:
 
-```yaml title=path/to/kratos/config.yml
-settings:
-  after:
-    hooks: []
-    password:
-      hooks: []
-    profile:
-      hooks: []
-  lifespan: 30m0s
-  // highlight-next-line
-  privileged_session_max_age: 15m0s
-  required_aal: highest_available
-  ui_url: /ui/settings
+```shell
+## List all available projects
+ory list projects
+
+## Get config
+ory get identity-config {project-id} --format yaml > identity-config.yaml
+```
+
+2. Update the configuration value for privileged session max age property (`privileged_session_max_age`) to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 15m30s, 1m).
+
+```yaml title="config.yml"
+selfservice:
+  flows:
+    settings:
+      after:
+        hooks: []
+        password:
+          hooks: []
+        profile:
+          hooks: []
+      ui_url: /ui/settings
+      // highlight-start
+      privileged_session_max_age: 15m
+      // highlight-end
+      required_aal: highest_available
+```
+
+3. Update the Ory Identities configuration using the file you worked with:
+
+```shell
+ ory update identity-config {project-id} --file identity-config.yaml
 ```
 
   </TabItem>
@@ -125,6 +145,8 @@ settings:
 
 With this configuration in place, the user can perform the actions that require a privileged session up to 15 minutes after
 signing in. When this time passes, the user must re-authenticate to access these options.
+
+### Demo
 
 Watch this video to see the flow in action:
 

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -48,7 +48,7 @@ An Ory Session Cookie is issued when the user signs in through a web browser. To
 
 ````mdx-code-block
 <Tabs groupId="sdk-console">
-<TabItem value="native" label="React">
+<TabItem value="React" label="React">
 
 ```mdx-code-block
 import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/selfservice/session/whoami-react.tsx"

--- a/docs/kratos/session-management/01_overview.mdx
+++ b/docs/kratos/session-management/01_overview.mdx
@@ -1,10 +1,15 @@
 ---
 id: overview
-title: Overview of sessions, session cookies, and session tokens in Ory
+title: Overview
 sidebar_label: Overview
 ---
 
-# Overview
+```mdx-code-block
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+import { getSdkUrl } from '@site/src/hooks'
+import CodeBlock from '@theme/CodeBlock'
+```
 
 When an identity or end-user authenticates, for example by signing in with their username and password, they receive an Ory
 Session. The session is proof that the user is authenticated and allows to interact with the system without the need to
@@ -39,37 +44,67 @@ response.
 An Ory Session Cookie is issued when the user signs in through a web browser. To get the session payload, send a request to the
 `/sessions/whoami` endpoint:
 
-```mdx-code-block
-import { getSdkUrl } from '@site/src/hooks'
-import CodeBlock from '@theme/CodeBlock'
+````mdx-code-block
+<Tabs groupId="sdk-console">
+<TabItem value="native" label="React">
 
+```mdx-code-block
+import reactWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/selfservice/session/whoami-react.tsx"
+
+<CodeBlock language="ts" title="Checking current session">{reactWhoAmI}</CodeBlock>
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+
+```mdx-code-block
 <CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
   -H 'Accept: application/json' \\
   -H 'Cookie: ory_kratos_session=MTYzNDIyNzEzN3xEdi1CQkFFQ180SUFBUkFCRUFBQVJfLUNBQUVHYzNSeWFXNW5EQThBRFhObGMzTnBiMjVmZEc5clpXNEdjM1J5YVc1bkRDSUFJRTFDYWtvME5VNVlaVWxvYVZWeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cL21Dclk3nCoXV41N6bFxvVJSt7CeICy_815Aw=='`}</CodeBlock>
 ```
+
+</TabItem>
+</Tabs>
+````
 
 ### Using Ory Session Token
 
 An Ory Session Token is issued when the user authenticates through a client other than a web browser. To get the session payload,
 send a request to the `/sessions/whoami` endpoint.
 
-You must pass the token in one of two ways:
+````mdx-code-block
+<Tabs groupId="sdk-console">
+<TabItem value="go" label="Go" default>
 
-- In the `Authorization` HTTP header:
+```mdx-code-block
+import goDisableSession from '!!raw-loader!../../../code-examples/sdk/go/selfservice/whoami.go'
+
+<CodeBlock language="go" title="Checking current session">{goDisableSession}</CodeBlock>
+```
+
+</TabItem>
+<TabItem value="native" label="TypeScript">
+
+```mdx-code-block
+import nativeWhoAmI from "!!raw-loader!@site/code-examples/sdk/typescript/src/selfservice/session/whoami-native.ts"
+
+<CodeBlock language="ts" title="Checking current session (Typescript SDK)">{nativeWhoAmI}</CodeBlock>
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
 
   ```mdx-code-block
   <CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
-    -H 'Accept: application/json' \
+    -H 'Accept: application/json' \\
     -H 'Authorization: Bearer BRFbGMzTnBiMjVmZEcEdjM1J5YVc1bkRDSUFvME5VNVlaVeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cLXV41N6bFxvVJSt7CeICy'`}</CodeBlock>
   ```
 
-- In the `X-Session-Token` HTTP header:
-
-  ```mdx-code-block
-  <CodeBlock language="shell">{`curl '${getSdkUrl().url}/sessions/whoami' \\
-    -H 'Accept: application/json' \
-    -H 'X-Session-Token: BRFbGMzTnBiMjVmZEcEdjM1J5YVc1bkRDSUFvME5VNVlaVeWJrUnZhSEF4YmxSV2VVRlhNMWwxVlVGenxXpsk2cLXV41N6bFxvVJSt7CeICy'`}</CodeBlock>
-  ```
+</TabItem>
+</Tabs>
+````
 
 ## Privileged Sessions
 
@@ -92,9 +127,6 @@ in the configuration.
 This is how you update the `privileged_session_max_age` to `15m`:
 
 ````mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <Tabs>
 <TabItem value="console" label="Ory Console" default>
 

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -57,23 +57,6 @@ session:
 ```
 
   </TabItem>
-  <TabItem value="selfhosted" label="Self-Hosted Ory Kratos config">
-
-```yaml title=path/to/kratos/config.yml
-// highlight-start
-session:
-  cookie:
-// highlight-end
-    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
-    name: ory_session_fancymoofasansuq4mdx5a
-    path: /
-    persistent: false
-    same_site: Lax
-// highlight-next-line
-  lifespan: 72h0m0s
-```
-
-  </TabItem>
 </Tabs>
 ````
 

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -46,7 +46,7 @@ session:
     persistent: false
     same_site: Lax
   // highlight-start
-  lifespan: 720h0m0s
+  lifespan: 720h
   // highlight-end
 ```
 

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -9,7 +9,8 @@ sidebar_label: Session lifespan
 Each session is valid for a set amount of time. This time is the session's lifespan. When the session lifespan expires, the user
 must re-authenticate.
 
-In the configuration, session lifespan is expressed in hours, minutes, and seconds. Use a combination of these units to define the desired lifespan. For example: `72h`, `10m`, `12s`, `1h13m3s`.
+In the configuration, session lifespan is expressed in hours, minutes, and seconds. Use a combination of these units to define the
+desired lifespan. For example: `72h`, `10m`, `12s`, `1h13m3s`.
 
 ````mdx-code-block
 import CodeBlock from '@theme/CodeBlock'

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -101,8 +101,8 @@ ory get identity-config {project-id} --format yaml > identity-config.yaml
 ```yaml title="config.yml"
 session:
   cookie:
-    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
-    name: ory_session_fancymoofasansuq4mdx5a
+    domain: {project.slug}.projects.oryapis.com
+    name: ory_session_{name}
     path: /
     // highlight-start
     persistent: false

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -41,8 +41,8 @@ ory get identity-config {project-id} --format yaml > identity-config.yaml
 ```yaml title="config.yml"
 session:
   cookie:
-    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
-    name: ory_session_fancymoofasansuq4mdx5a
+    domain: {project.slug}.projects.oryapis.com
+    name: ory_session_{name}
     path: /
     persistent: false
     same_site: Lax

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -9,8 +9,7 @@ sidebar_label: Session lifespan
 Each session is valid for a set amount of time. This time is the session's lifespan. When the session lifespan expires, the user
 must re-authenticate.
 
-In the configuration, the session lifespan is expressed in hours, minutes and seconds combination (hour (h), minute (m), second
-(s) to define interval, for example: **1h1m10s**, **10s**, **1h**).
+In the configuration, session lifespan is expressed in hours, minutes, and seconds. Use a combination of these units to define the desired lifespan. For example: `72h`, `10m`, `12s`, `1h13m3s`.
 
 ````mdx-code-block
 import CodeBlock from '@theme/CodeBlock'

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="console" label="Ory Console" default>
 
-To change the session lifespan, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired lifespan value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h) and click the **Save** button.
+To change the session lifespan, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired lifespan and click the **Save** button.
 
 For example, to set the session lifespan to 30 days, enter `720h0m0s`.
 

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -9,9 +9,8 @@ sidebar_label: Session lifespan
 Each session is valid for a set amount of time. This time is the session's lifespan. When the session lifespan expires, the user
 must re-authenticate.
 
-In the configuration, the session lifespan is expressed in hours.
-
-Run this command to adjust the session lifespan to 720 hours (30 days):
+In the configuration, the session lifespan is expressed in hours, minutes and seconds combination (hour (h), minute (m), second
+(s) to define interval, for example: **1h1m10s**, **10s**, **1h**).
 
 ````mdx-code-block
 import CodeBlock from '@theme/CodeBlock'
@@ -19,11 +18,43 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-  <TabItem value="cloud" label="Ory CLI" default>
+  <TabItem value="console" label="Ory Console" default>
+
+To change the session lifespan, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired lifespan value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h) and click the **Save** button.
+
+For example, to set the session lifespan to 30 days, enter `720h0m0s`.
+
+  </TabItem>
+  <TabItem value="cloud" label="Ory CLI">
+1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell
-ory patch identity-config <your-project-id> \\
-  --replace '/session/lifespan="720h"' # 30 days
+## List all available projects
+ory list projects
+
+## Get config
+ory get identity-config {project-id} --format yaml > identity-config.yaml
+```
+
+2. Update the configuration value for session lifespan property to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
+
+```yaml title="config.yml"
+session:
+  cookie:
+    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
+    name: ory_session_fancymoofasansuq4mdx5a
+    path: /
+    persistent: false
+    same_site: Lax
+  // highlight-start
+  lifespan: 720h0m0s
+  // highlight-end
+```
+
+3. Update the Ory Identities configuration using the file you worked with:
+
+```shell
+ ory update identity-config {project-id} --file identity-config.yaml
 ```
 
   </TabItem>

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -26,6 +26,7 @@ For example, to set the session lifespan to 30 days, enter `720h`.
 
   </TabItem>
   <TabItem value="cloud" label="Ory CLI">
+
 1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell
@@ -69,6 +70,7 @@ different cookie `max-age`, set the `session/cookie/persistent` value to `false`
 ````mdx-code-block
 <Tabs>
   <TabItem value="cloud" label="Ory CLI" default>
+
 1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -36,7 +36,7 @@ ory list projects
 ory get identity-config {project-id} --format yaml > identity-config.yaml
 ```
 
-2. Update the configuration value for session lifespan property to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
+2. Update the configuration value for session lifespan property to the desired value:
 
 ```yaml title="config.yml"
 session:

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -86,10 +86,35 @@ different cookie `max-age`, set the `session/cookie/persistent` value to `false`
 ````mdx-code-block
 <Tabs>
   <TabItem value="cloud" label="Ory CLI" default>
+1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell
-ory patch identity-config <your-project-id> \\
-  --replace '/session/cookie/persistent=false'
+## List all available projects
+ory list projects
+
+## Get config
+ory get identity-config {project-id} --format yaml > identity-config.yaml
+```
+
+2. Update the configuration value for session lifespan property to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
+
+```yaml title="config.yml"
+session:
+  cookie:
+    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
+    name: ory_session_fancymoofasansuq4mdx5a
+    path: /
+    // highlight-start
+    persistent: false
+    // highlight-end
+    same_site: Lax
+  lifespan: 720h0m0s
+```
+
+3. Update the Ory Identities configuration using the file you worked with:
+
+```shell
+ ory update identity-config {project-id} --file identity-config.yaml
 ```
 
   </TabItem>
@@ -111,8 +136,12 @@ session:
 </Tabs>
 ````
 
+:::note
+
 If `max-age` is set as a part of the `Set-Cookie` header, the browser deletes the cookie when it reaches the age defined in
 `max-age`.
 
 When `max-age` is not set, the browser deletes the cookie when the session ends. The session ends when the set session lifespan
 expires, or when the browser is shut down by the user.
+
+:::

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 To change the session lifespan, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired lifespan and click the **Save** button.
 
-For example, to set the session lifespan to 30 days, enter `720h0m0s`.
+For example, to set the session lifespan to 30 days, enter `720h`.
 
   </TabItem>
   <TabItem value="cloud" label="Ory CLI">

--- a/docs/kratos/session-management/10_session-lifespan.mdx
+++ b/docs/kratos/session-management/10_session-lifespan.mdx
@@ -12,53 +12,55 @@ must re-authenticate.
 In the configuration, session lifespan is expressed in hours, minutes, and seconds. Use a combination of these units to define the
 desired lifespan. For example: `72h`, `10m`, `12s`, `1h13m3s`.
 
-````mdx-code-block
+```mdx-code-block
 import CodeBlock from '@theme/CodeBlock'
 import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import TabItem from '@theme/TabItem'
+```
 
+````mdx-code-block
 <Tabs>
-  <TabItem value="console" label="Ory Console" default>
+<TabItem value="console" label="Ory Console" default>
 
 To change the session lifespan, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired lifespan and click the **Save** button.
 
 For example, to set the session lifespan to 30 days, enter `720h`.
 
-  </TabItem>
-  <TabItem value="cloud" label="Ory CLI">
+</TabItem>
+<TabItem value="cloud" label="Ory CLI">
 
 1. Download the Ory Identities config from your project and save it to a file:
 
-```shell
-## List all available projects
-ory list projects
+   ```shell
+   ## List all available projects
+   ory list projects
 
-## Get config
-ory get identity-config {project-id} --format yaml > identity-config.yaml
-```
+   ## Get config
+   ory get identity-config {project-id} --format yaml > identity-config.yaml
+   ```
 
 2. Update the configuration value for session lifespan property to the desired value:
 
-```yaml title="config.yml"
-session:
-  cookie:
-    domain: {project.slug}.projects.oryapis.com
-    name: ory_session_{name}
-    path: /
-    persistent: false
-    same_site: Lax
-  // highlight-start
-  lifespan: 720h
-  // highlight-end
-```
+   ```yaml title="config.yml"
+   session:
+   cookie:
+      domain: {project.slug}.projects.oryapis.com
+      name: ory_session_{name}
+      path: /
+      persistent: false
+      same_site: Lax
+   // highlight-start
+   lifespan: 720h
+   // highlight-end
+   ```
 
 3. Update the Ory Identities configuration using the file you worked with:
 
-```shell
- ory update identity-config {project-id} --file identity-config.yaml
-```
+   ```shell
+   ory update identity-config {project-id} --file identity-config.yaml
+   ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 ````
 
@@ -69,55 +71,40 @@ different cookie `max-age`, set the `session/cookie/persistent` value to `false`
 
 ````mdx-code-block
 <Tabs>
-  <TabItem value="cloud" label="Ory CLI" default>
+<TabItem value="cloud" label="Ory CLI" default>
 
 1. Download the Ory Identities config from your project and save it to a file:
 
-```shell
-## List all available projects
-ory list projects
+   ```shell
+   ## List all available projects
+   ory list projects
 
-## Get config
-ory get identity-config {project-id} --format yaml > identity-config.yaml
-```
+   ## Get config
+   ory get identity-config {project-id} --format yaml > identity-config.yaml
+   ```
 
 2. Update the configuration value for session lifespan property to the desired value (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
 
-```yaml title="config.yml"
-session:
-  cookie:
-    domain: {project.slug}.projects.oryapis.com
-    name: ory_session_{name}
-    path: /
-    // highlight-start
-    persistent: false
-    // highlight-end
-    same_site: Lax
-  lifespan: 720h0m0s
-```
+   ```yaml title="config.yml"
+   session:
+   cookie:
+      domain: {project.slug}.projects.oryapis.com
+      name: ory_session_{name}
+      path: /
+      // highlight-start
+      persistent: false
+      // highlight-end
+      same_site: Lax
+   lifespan: 720h0m0s
+   ```
 
 3. Update the Ory Identities configuration using the file you worked with:
 
-```shell
- ory update identity-config {project-id} --file identity-config.yaml
-```
+   ```shell
+   ory update identity-config {project-id} --file identity-config.yaml
+   ```
 
-  </TabItem>
-  <TabItem value="macos" label="Self-Hosted Ory Kratos Config" default>
-
-```yaml title=path/to/kratos/config.yml
-// highlight-next-line
-session:
-  cookie:
-    domain: fancy-moofasa-nsuq4mdx5a.projects.oryapis.com
-    name: ory_session_fancymoofasansuq4mdx5a
-    path: /
-    // highlight-next-line
-    persistent: false
-    same_site: Lax
-```
-
-  </TabItem>
+</TabItem>
 </Tabs>
 ````
 
@@ -130,3 +117,71 @@ When `max-age` is not set, the browser deletes the cookie when the session ends.
 expires, or when the browser is shut down by the user.
 
 :::
+
+## Privileged sessions
+
+To perform some profile changes, such as updating the email address, password, or adding/removing 2FA, the user must have a
+privileged session.
+
+:::tip
+
+This flow is similar to [GitHub's sudo mode](https://help.github.com/en/github/authenticating-to-github/sudo-mode).
+
+:::
+
+The session is considered privileged when its `authenticated_at` is younger than the `privileged_session_max_age` value defined in
+the configuration.
+
+### Configuration
+
+````mdx-code-block
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+To change the privileged session duration, go to [**Ory Console**](https://console.ory.sh/) → **Session Settings**, enter the desired value in the **Privileged Session Age** field and click the **Save** button.
+
+For example, to set the privileged session duration to 15 minutes, enter `15m`.
+
+</TabItem>
+<TabItem value="cloud" label="Ory CLI">
+
+1. Download the Ory Identities config from your project and save it to a file.
+
+   ```shell
+   ## List all available projects
+   ory list projects
+
+   ## Get config
+   ory get identity-config {project-id} --format yaml > identity-config.yaml
+   ```
+
+2. Update the configuration value for privileged session max age property (`privileged_session_max_age`) to the desired value. For example, to set the privileged session duration to 15 minutes, enter `15m`.
+
+   ```yaml title="config.yml"
+   selfservice:
+   flows:
+      settings:
+         after:
+         hooks: []
+         password:
+            hooks: []
+         profile:
+            hooks: []
+         ui_url: /ui/settings
+         // highlight-next-line
+         privileged_session_max_age: 15m
+         required_aal: highest_available
+   ```
+
+3. Update the Ory Identities configuration using the file you worked with.
+
+   ```shell
+   ory update identity-config {project-id} --file identity-config.yaml
+   ```
+
+</TabItem>
+</Tabs>
+````
+
+With this configuration in place, the user can perform the actions that require a privileged session up to 15 minutes after
+signing in. When this time passes, the user must re-authenticate to access these options.

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -51,8 +51,7 @@ To get the Session ID, call the `/sessions/whoami` endpoint or `toSession` SDK m
 
 ## Refresh threshold
 
-You can limit the time in which the session can be refreshed by adjusting the
-`earliest_possible_extend` configuration.
+You can limit the time in which the session can be refreshed by adjusting the `earliest_possible_extend` configuration.
 
 For example, if you set `earliest_possible_extend` to `24h`, sessions can't be refreshed sooner than 24 hours before they expire.
 
@@ -64,7 +63,6 @@ to be refreshed during their entire lifespan, even right after they are created.
 If you set `earliest_possible_extend` to `lifespan`, all sessions will constantly be refreshed!
 
 :::
-
 
 ````mdx-code-block
 <Tabs>

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -15,7 +15,27 @@ For certain use cases, sessions need to be refreshed on user activity or adminis
 When you refresh a session, its `expires` property is set to a value that is the time when the refresh is triggered plus the
 amount of time defined by the value of `/session/lifespan`.
 
-## Refresh sessions as administrator
+## Forcing session refresh
+
+You can force users to refresh session by prompting them to re-authenticate by interacting with the
+[`/self-service/login/browser`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowForBrowsers) or
+[`/self-service/login/api`](../../reference/api.mdx#operation/initializeSelfServiceLoginFlowWithoutBrowser) APIs and setting the
+`refresh` parameter to true.
+
+When the user re-authenticates, the `authenticated_at` timestamp of the session is set to the time when user re-authenticated.
+
+```mdx-code-block
+<CodeBlock language="shell">{`${getSdkUrl().url}/self-service/login/browser?refresh=true`}</CodeBlock>
+```
+
+When forcing users to refresh sessions, you can also force them to refresh their second authentication factor. To do that, set
+`refresh=true` and `aal=aal2`:
+
+```mdx-code-block
+<CodeBlock language="shell">{`${getSdkUrl().url}/self-service/login/browser?refresh=true&aal=aal2`}</CodeBlock>
+```
+
+## Refreshing sessions as administrator
 
 Administrators can refresh the session of a specific user using the
 [extend session API](../../reference/api#tag/identity/operation/extendSession) from the SDK.
@@ -66,40 +86,40 @@ If you set `earliest_possible_extend` to `lifespan`, all sessions will constantl
 
 ````mdx-code-block
 <Tabs>
-  <TabItem value="cloud" label="Ory CLI" default>
+<TabItem value="cloud" label="Ory CLI" default>
 
 1. Download the Ory Identities config from your project and save it to a file:
 
-```shell
-## List all available projects
-ory list projects
+   ```shell
+   ## List all available projects
+   ory list projects
 
-## Get config
-ory get identity-config {project-id} --format yaml > identity-config.yaml
-```
+   ## Get config
+   ory get identity-config {project-id} --format yaml > identity-config.yaml
+   ```
 
 2. Update the configuration value for the property to the desired value. (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
 
-```yaml title="config.yml"
-session:
-  cookie:
-    domain: {project.slug}.projects.oryapis.com
-    name: ory_session_{name}
-    path: /
-    persistent: false
-    same_site: Lax
-  lifespan: 720h0m0s
-  // highlight-start
-  earliest_possible_extend: 24h0m0s
-  // highlight-end
-```
+   ```yaml title="config.yml"
+   session:
+   cookie:
+      domain: {project.slug}.projects.oryapis.com
+      name: ory_session_{name}
+      path: /
+      persistent: false
+      same_site: Lax
+   lifespan: 720h0m0s
+   // highlight-start
+   earliest_possible_extend: 24h0m0s
+   // highlight-end
+   ```
 
 3. Update the Ory Identities configuration using the file you worked with:
 
-```shell
- ory update identity-config {project-id} --file identity-config.yaml
-```
+   ```shell
+   ory update identity-config {project-id} --file identity-config.yaml
+   ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 ````

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -27,7 +27,7 @@ Administrators can refresh the session of a specific user using the
 ```mdx-code-block
 import goExtendSession from '!!raw-loader!../../../code-examples/sdk/go/session/refresh-session.go'
 
-<CodeBlock language="go">{goExtendSession}</CodeBlock>
+<CodeBlock language="go" title="extend-session.go">{goExtendSession}</CodeBlock>
 ```
 
 </TabItem>

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -67,6 +67,7 @@ If you set `earliest_possible_extend` to `lifespan`, all sessions will constantl
 ````mdx-code-block
 <Tabs>
   <TabItem value="cloud" label="Ory CLI" default>
+
 1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -49,15 +49,12 @@ To get the Session ID, call the `/sessions/whoami` endpoint or `toSession` SDK m
 
 :::
 
-## Reduce database load
+## Refresh threshold
 
-Refreshing sessions causes database writes.
-
-To reduce the database load, you can limit the time in which the session can be refreshed by adjusting the
+You can limit the time in which the session can be refreshed by adjusting the
 `earliest_possible_extend` configuration.
 
 For example, if you set `earliest_possible_extend` to `24h`, sessions can't be refreshed sooner than 24 hours before they expire.
-This setting prevents putting excessive load on the database.
 
 If you need high flexibility when extending sessions, you can set `earliest_possible_extend` to `lifespan`, which allows sessions
 to be refreshed during their entire lifespan, even right after they are created.
@@ -68,21 +65,40 @@ If you set `earliest_possible_extend` to `lifespan`, all sessions will constantl
 
 :::
 
+
 ````mdx-code-block
 <Tabs>
   <TabItem value="cloud" label="Ory CLI" default>
+1. Download the Ory Identities config from your project and save it to a file:
 
 ```shell
-ory patch identity-config <your-project-id> \\
-  --replace '/session/earliest_possible_extend="24h"'
+## List all available projects
+ory list projects
+
+## Get config
+ory get identity-config {project-id} --format yaml > identity-config.yaml
 ```
 
-  </TabItem>
-  <TabItem value="selfhosted" label="Self-Hosted Ory Kratos config">
+2. Update the configuration value for the property to the desired value. (Use hour (h), minute (m), second (s) to define interval, for example: 1h1m10s, 10s, 1h)
 
-```yaml title=path/to/kratos/config.yml
+```yaml title="config.yml"
 session:
+  cookie:
+    domain: {project.slug}.projects.oryapis.com
+    name: ory_session_{name}
+    path: /
+    persistent: false
+    same_site: Lax
+  lifespan: 720h0m0s
+  // highlight-start
   earliest_possible_extend: 24h0m0s
+  // highlight-end
+```
+
+3. Update the Ory Identities configuration using the file you worked with:
+
+```shell
+ ory update identity-config {project-id} --file identity-config.yaml
 ```
 
   </TabItem>

--- a/docs/kratos/session-management/20_refresh-extend-session.mdx
+++ b/docs/kratos/session-management/20_refresh-extend-session.mdx
@@ -3,6 +3,13 @@ id: refresh-extend-sessions
 title: Refresh and extend sessions
 ---
 
+```mdx-code-block
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+import { getSdkUrl } from '@site/src/hooks'
+import CodeBlock from '@theme/CodeBlock'
+```
+
 For certain use cases, sessions need to be refreshed on user activity or administrative action.
 
 When you refresh a session, its `expires` property is set to a value that is the time when the refresh is triggered plus the
@@ -10,16 +17,31 @@ amount of time defined by the value of `/session/lifespan`.
 
 ## Refresh sessions as administrator
 
-To extend a session's lifespan, call the administrative
-[`adminRefreshSession`](../../reference/api.mdx#operation/adminRefreshSession) endpoint with the session ID:
+Administrators can refresh the session of a specific user using the
+[extend session API](../../reference/api#tag/identity/operation/extendSession) from the SDK.
+
+````mdx-code-block
+<Tabs groupId="sdk-console">
+<TabItem value="go" label="Go" default>
 
 ```mdx-code-block
-import { getSdkUrl } from '@site/src/hooks'
-import CodeBlock from '@theme/CodeBlock'
+import goExtendSession from '!!raw-loader!../../../code-examples/sdk/go/session/refresh-session.go'
 
-<CodeBlock>{`PATCH ${getSdkUrl().url}/admin/sessions/{id}/refresh
-Authorization: Bearer {your-personal-access-token}`}</CodeBlock>
+<CodeBlock language="go">{goExtendSession}</CodeBlock>
 ```
+
+</TabItem>
+<TabItem value="native" label="TypeScript">
+
+```mdx-code-block
+import nativeExtendSession from "!!raw-loader!@site/code-examples/sdk/typescript/src/session/refresh-session-native.ts"
+
+<CodeBlock language="ts" title="extend-session-native.ts">{nativeExtendSession}</CodeBlock>
+```
+
+</TabItem>
+</Tabs>
+````
 
 :::tip
 


### PR DESCRIPTION
## Changes
- Refreshing overview, lifespan and refresh/extend documentation
- Drop `Session` blob in the doc and link to API reference