### PR TITLE
docs: update community examples with Hydra Java example

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,12 +428,12 @@ Ory examples. To add a new example or modify existing entries:
 
     ```tsx
     {
-          title: 'Protect a Page with Login: NextJs/React', //Your example title goes here
-          language: 'typescript',                           //The main programming language of your example
-          author: 'ory',                                    //The author's GitHub handle
+          title: "Protect a Page with Login: NextJs/React", //Your example title goes here
+          language: "typescript",                           //The main programming language of your example
+          author: "ory",                                    //The author's GitHub handle
           tested: true,                                     //Is the example in ory/examples or ory/docs and has automated tests?
-          repo: 'https://github.com/ory/docs/tree/master/code-examples/protect-page-login/nextjs', //The repo containing the example code
-          docs: 'https://www.ory.sh/docs/guides/protect-page-login/next.js'                        //Documentation for the example, can be README, blog article or similar
+          repo: "https://github.com/ory/docs/tree/master/code-examples/protect-page-login/nextjs", //The repo containing the example code
+          docs: "https://www.ory.sh/docs/guides/protect-page-login/next.js"                        //Documentation for the example, can be README, blog article or similar
         },
     ```
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Ory examples. To add a new example or modify existing entries:
           author: "ory",                                    //The author's GitHub handle
           tested: true,                                     //Is the example in ory/examples or ory/docs and has automated tests?
           repo: "https://github.com/ory/docs/tree/master/code-examples/protect-page-login/nextjs", //The repo containing the example code
-          docs: "https://www.ory.sh/docs/guides/protect-page-login/next.js"                        //Documentation for the example, can be README, blog article or similar
+          docs: "https://www.ory.sh/docs/guides/protect-page-login/next.js",                       //Documentation for the example, can be README, blog article or similar
         },
     ```
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ For a better workflow, install the Prettier plugin for your editor:
 [The "Examples" page](https://www.ory.sh/docs/examples) provides an overview of
 Ory examples. To add a new example or modify existing entries:
 
-1.  Open `examples-content.tsx` in `docs/src/pages/_assets/`.
+1.  Open `examples-content.tsx` in `src/pages/_assets/`.
 2.  Copy the following snippet and append it to the correct array (either
     official, community, or self-hosting examples):
 

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -230,7 +230,7 @@ export const community: PropTypes = {
       author: "ardetrick",
       tested: false,
       repo: "https://github.com/ardetrick/ory-hydra-refrence-java",
-      docs: "https://github.com/ardetrick/ory-hydra-refrence-java/blob/main/README.md"
+      docs: "https://github.com/ardetrick/ory-hydra-refrence-java/blob/main/README.md",
     },
   ],
 }

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -224,6 +224,14 @@ export const community: PropTypes = {
       repo: "https://github.com/emrahcom/kratos-selfservice-svelte-node",
       docs: "https://github.com/emrahcom/kratos-selfservice-svelte-node/blob/master/README.md",
     },
+    {
+      title: 'Ory Hydra Reference Implementation - Java - Spring',
+      language: 'java',
+      author: 'ardetrick',
+      tested: false,
+      repo: 'https://github.com/ardetrick/ory-hydra-refrence-java',
+      docs: 'https://github.com/ardetrick/ory-hydra-refrence-java/blob/main/README.md'
+    },
   ],
 }
 

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -225,12 +225,12 @@ export const community: PropTypes = {
       docs: "https://github.com/emrahcom/kratos-selfservice-svelte-node/blob/master/README.md",
     },
     {
-      title: 'Ory Hydra Reference Implementation - Java - Spring',
-      language: 'java',
-      author: 'ardetrick',
+      title: "Ory Hydra Reference Implementation - Java - Spring",
+      language: "java",
+      author: "ardetrick",
       tested: false,
-      repo: 'https://github.com/ardetrick/ory-hydra-refrence-java',
-      docs: 'https://github.com/ardetrick/ory-hydra-refrence-java/blob/main/README.md'
+      repo: "https://github.com/ardetrick/ory-hydra-refrence-java",
+      docs: "https://github.com/ardetrick/ory-hydra-refrence-java/blob/main/README.md"
     },
   ],
 }


### PR DESCRIPTION
Adds a new community example of how to use Ory Hydra with Java and Spring.

Also fixes some small errors in `README.md` around committing examples:
- path included the repository name when I believe the intent is to use the path relative to this this repository
- linter does not allow single quotes (`'`) so the example has been updated with the expected double quote (`"`) usage
- linter requires a trailing comma (`,`) so the example has been updated with the expected trailing comma

## Related Issue or Design Document

N/A.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

N/A.