### PR TITLE
fix: table for sdks

### DIFF
--- a/docs/sdk.mdx
+++ b/docs/sdk.mdx
@@ -13,17 +13,20 @@ various programming languages.
 
 Ory publishes SDKs for popular languages in their respective package repositories:
 
-- [Dart](https://pub.dev/packages/ory_client)
-- [.NET](https://www.nuget.org/packages/Ory.Client/)
-- [Elixir](https://hex.pm/packages/ory_client)
-- [Go](https://github.com/ory/client-go)
-- [Java](https://search.maven.org/artifact/sh.ory/ory-client)
-- [JavaScript](https://www.npmjs.com/package/@ory/client) with TypeScript definitions and compatible with: Node.js, React.js,
-  Angular, Vue.js, and many more.
-- [PHP](https://packagist.org/packages/ory/client)
-- [Python](https://pypi.org/project/ory-client/)
-- [Ruby](https://rubygems.org/gems/ory-client)
-- [Rust](https://crates.io/crates/ory-client)
+| Language       | Download SDK                                                     | Documentation                                                                        |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Dart           | [pub.dev](https://pub.dev/packages/ory_client)                   | [README](https://github.com/ory/sdk/blob/master/clients/client/dart/README.md)       |
+| .NET           | [nuget.org](https://www.nuget.org/packages/Ory.Client/)          | [README](https://github.com/ory/sdk/blob/master/clients/client/dotnet/README.md)     |
+| Elixir         | [hex.pm](https://hex.pm/packages/ory_client)                     | [README](https://github.com/ory/sdk/blob/master/clients/client/elixir/README.md)     |
+| Go             | [github.com](https://github.com/ory/client-go)                   | [README](https://github.com/ory/sdk/blob/master/clients/client/go/README.md)         |
+| Java           | [maven.org](https://search.maven.org/artifact/sh.ory/ory-client) | [README](https://github.com/ory/sdk/blob/master/clients/client/java/README.md)       |
+| JavaScript[^1] | [npmjs.com](https://www.npmjs.com/package/@ory/client)           | [README](https://github.com/ory/sdk/blob/master/clients/client/typescript/README.md) |
+| PHP            | [packagist.org](https://packagist.org/packages/ory/client)       | [README](https://github.com/ory/sdk/blob/master/clients/client/php/README.md)        |
+| Python         | [pypi.org](https://pypi.org/project/ory-client/)                 | [README](https://github.com/ory/sdk/blob/master/clients/client/python/README.md)     |
+| Ruby           | [rubygems.org](https://rubygems.org/gems/ory-client)             | [README](https://github.com/ory/sdk/blob/master/clients/client/ruby/README.md)       |
+| Rust           | [crates.io](https://crates.io/crates/ory-client)                 | [README](https://github.com/ory/sdk/blob/master/clients/client/rust/README.md)       |
+
+[^1] with TypeScript definitions and compatible with: Node.js, React.js, Angular, Vue.js, and more.
 
 ## Further information
 


### PR DESCRIPTION
As proposed here: https://github.com/ory/client-ruby/issues/2#issuecomment-1372283629 

- adds table to the /sdk page to give a concise overview of all SDKs and links to the documentation for each SKD. 

We could add links to the examples as well, but should be easy to find in the sidebar (plus we dont have examples for most languages yet...)

Once this is merged/approved I will add the table for the selfhosting SDKs as well.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
