### PR TITLE
fix: corrected typo in OPL npm install command

### DIFF
--- a/docs/keto/guides/userset-rewrites.mdx
+++ b/docs/keto/guides/userset-rewrites.mdx
@@ -149,7 +149,7 @@ Next, create a file with the same namespace configuration as above.
 :::tip
 
 If you are using a text editor with TypeScript support, you can get extra help when using the Ory Permission Language. Make sure
-to run `npm i @ory/keto-namespaces-types` and add a `tsconfig.json` file with the content:
+to run `npm i @ory/keto-namespace-types` and add a `tsconfig.json` file with the content:
 
 ```mdx-code-block
 <CodeFromRemote src={file("tsconfig.json")} title="tsconfig.json" />


### PR DESCRIPTION
Fixes a typo in the tips section toward the bottom of [this page](https://www.ory.sh/docs/keto/guides/userset-rewrites), where an npm install command points to `@ory/keto-namespaces-types` instead of `@ory/keto-namespace-types`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).