### PR TITLE
docs: add missing Ory Console tabs for social sign-in providers

### DIFF
--- a/docs/kratos/social-signin/05_generic.mdx
+++ b/docs/kratos/social-signin/05_generic.mdx
@@ -110,7 +110,7 @@ Follow these steps to add a generic provider as a social sign-in provider to you
 6. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/10_google.mdx
+++ b/docs/kratos/social-signin/10_google.mdx
@@ -213,7 +213,7 @@ Follow these steps to add Google as a social sign-in provider to your project us
 6. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/15_facebook.mdx
+++ b/docs/kratos/social-signin/15_facebook.mdx
@@ -166,7 +166,7 @@ Follow these steps to add Facebook as a social sign-in provider to your project 
 6. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/20_microsoft.mdx
+++ b/docs/kratos/social-signin/20_microsoft.mdx
@@ -173,7 +173,7 @@ Follow these steps to add Microsoft as a social sign-in provider to your project
 6. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/25_github.mdx
+++ b/docs/kratos/social-signin/25_github.mdx
@@ -189,7 +189,7 @@ Follow these steps to add GitHub as a social sign-in provider to your project us
 6. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -4,7 +4,9 @@ title: Add Apple as a social sign-in provider in Ory
 sidebar_label: Apple
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # Apple
 
@@ -31,6 +33,7 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
     - **Apple Private Key Id**
     - **Apple Private Key**
 9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: false,
@@ -62,7 +65,8 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 
 Follow these steps to add Apple as a social sign-in provider to your project using the Ory CLI:
 
-1. [Create an app, a service, and a private key using an Apple Developer account](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple#create-an-app-id).
+1. Follow the [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) guide to
+   [create an app, a service, and a private key using an Apple Developer account](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple).
 2. In the created app, set the redirect URI to:
 
    ```shell

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -28,15 +28,16 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 2. Click the switch next to the Apple logo to start the configuration.
 3. Copy the Redirect URI and save it for later use.
 4. Using an Apple Developer Account, create an app, a service, and a private key.
-5. Copy the **Services ID** from the Apple registered app to the **Client ID** field in the form on the Ory Console.
+5. Copy the **Services ID** from the Apple registered app to the **Client ID** field in the form in the Ory Console.
 6. Add the saved Redirect URI from Ory to the **Return URLs** of the Apple registered application.
-7. In the **Scopes** field of the form on the Ory Console, add the following scope:
+7. In the **Scopes** field of the form in the Ory Console, add the following scope:
     - `email`
 8. Copy the following details from your registered application in Apple to the corresponding fields in the Ory Console form:
     - **Apple Team Id**
     - **Apple Private Key Id**
     - **Apple Private Key**
-9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+9. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+   which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -4,6 +4,8 @@ title: Add Apple as a social sign-in provider in Ory
 sidebar_label: Apple
 ---
 
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+
 # Apple
 
 ````mdx-code-block
@@ -14,6 +16,44 @@ import TabItem from '@theme/TabItem';
 <TabItem value="console" label="Ory Console" default>
 
 Follow these steps to add Apple as a social sign-in provider to your project using the Ory Console:
+
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the Apple logo to start the configuration.
+3. Copy the **Redirect URI** and save it for later use.
+4. Follow the [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) guide to
+   [create an app, a service, and a private key using an Apple Developer account](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple).
+5. Copy the **Services ID** from the Apple registered app to the **Client ID** field in the form on the Ory Console.
+5. Add the saved **Redirect URI** from Ory to the **Return URLs** of the Apple registered application.
+6. In the **Scopes** field of the form on the Ory Console, add the following scope:
+    - `email`
+7. Copy the following details from your registered application in Apple to the Ory Console form:
+    1. Copy the **Apple Team Id** to the corresponding field in the form on the Ory Console.
+    2. Copy the **Apple Private Key Id** to the corresponding field in the form on the Ory Console.
+    3. Copy the **Apple Private Key** to the corresponding field in the form on the Ory Console.
+8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: false,
+   } + std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // Therefore we only return the email if it (a) exists and (b) is marked verified
+         // by Apple.
+         [if 'email' in claims && claims.email_verified then 'email' else null]: claims.email,
+       },
+     },
+   }
+   ```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+9. Click **Save Configuration**.
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
@@ -48,13 +88,9 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
      },
    }
    ```
-
-```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
-<JsonnetWarning />
-```
-
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 
    ```shell

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -148,7 +148,7 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -4,13 +4,18 @@ title: Add Apple as a social sign-in provider in Ory
 sidebar_label: Apple
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
 
 # Apple
 
+:::note
+
+To add Apple as a social sign-in provider, you need an Apple Developer account. Go to
+[Enrolling and Verifying Your Identity with the Apple Developer App](https://developer.apple.com/support/app-account/) to create one.
+
+:::
+
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -21,11 +26,10 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the Apple logo to start the configuration.
-3. Copy the **Redirect URI** and save it for later use.
-4. Follow the [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) guide to
-   [create an app, a service, and a private key using an Apple Developer account](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple).
+3. Copy the Redirect URI and save it for later use.
+4. Using an Apple Developer Account, create an app, a service, and a private key.
 5. Copy the **Services ID** from the Apple registered app to the **Client ID** field in the form on the Ory Console.
-6. Add the saved **Redirect URI** from Ory to the **Return URLs** of the Apple registered application.
+6. Add the saved Redirect URI from Ory to the **Return URLs** of the Apple registered application.
 7. In the **Scopes** field of the form on the Ory Console, add the following scope:
     - `email`
 8. Copy the following details from your registered application in Apple to the corresponding fields in the Ory Console form:
@@ -65,8 +69,7 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 
 Follow these steps to add Apple as a social sign-in provider to your project using the Ory CLI:
 
-1. Follow the [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) guide to
-   [create an app, a service, and a private key using an Apple Developer account](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple).
+1. Using an Apple Developer Account, create an app, a service, and a private key.
 2. In the created app, set the redirect URI to:
 
    ```shell
@@ -94,6 +97,7 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -6,6 +6,18 @@ sidebar_label: Apple
 
 # Apple
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Apple as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add Apple as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create an app, a service, and a private key using an Apple Developer account](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple#create-an-app-id).
@@ -91,3 +103,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -10,7 +10,8 @@ sidebar_label: Apple
 :::note
 
 To add Apple as a social sign-in provider, you need an Apple Developer account. Go to
-[Enrolling and Verifying Your Identity with the Apple Developer App](https://developer.apple.com/support/app-account/) to create one.
+[Enrolling and Verifying Your Identity with the Apple Developer App](https://developer.apple.com/support/app-account/)
+to create one.
 
 :::
 

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -10,8 +10,8 @@ sidebar_label: Apple
 :::note
 
 To add Apple as a social sign-in provider, you need an Apple Developer account. Go to
-[Enrolling and Verifying Your Identity with the Apple Developer App](https://developer.apple.com/support/app-account/)
-to create one.
+[Enrolling and Verifying Your Identity with the Apple Developer App](https://developer.apple.com/support/app-account/) to create
+one.
 
 :::
 

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -23,14 +23,14 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
 4. Follow the [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) guide to
    [create an app, a service, and a private key using an Apple Developer account](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple).
 5. Copy the **Services ID** from the Apple registered app to the **Client ID** field in the form on the Ory Console.
-5. Add the saved **Redirect URI** from Ory to the **Return URLs** of the Apple registered application.
-6. In the **Scopes** field of the form on the Ory Console, add the following scope:
+6. Add the saved **Redirect URI** from Ory to the **Return URLs** of the Apple registered application.
+7. In the **Scopes** field of the form on the Ory Console, add the following scope:
     - `email`
-7. Copy the following details from your registered application in Apple to the Ory Console form:
-    1. Copy the **Apple Team Id** to the corresponding field in the form on the Ory Console.
-    2. Copy the **Apple Private Key Id** to the corresponding field in the form on the Ory Console.
-    3. Copy the **Apple Private Key** to the corresponding field in the form on the Ory Console.
-8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+8. Copy the following details from your registered application in Apple to the corresponding fields in the Ory Console form:
+    - **Apple Team Id**
+    - **Apple Private Key Id**
+    - **Apple Private Key**
+9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
    ```jsonnet
    local claims = {
      email_verified: false,
@@ -50,10 +50,12 @@ Follow these steps to add Apple as a social sign-in provider to your project usi
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
-9. Click **Save Configuration**.
+
+10. Click **Save Configuration**.
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">

--- a/docs/kratos/social-signin/30_apple.mdx
+++ b/docs/kratos/social-signin/30_apple.mdx
@@ -4,7 +4,6 @@ title: Add Apple as a social sign-in provider in Ory
 sidebar_label: Apple
 ---
 
-
 # Apple
 
 :::note

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -20,27 +20,29 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the GitLab logo to start the configuration.
 3. Copy the Redirect URI and save it for later use.
-4. [Create a GitLab OAuth2 Application](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile),
-  noting the following points:
-    - Paste the saved **Redirect URI** from Ory into the **Redirect URI** field in the GitLab form.
-    - Enable the relevant **Scopes** for the application, by ticking the relevant boxes in the GitLab form:
-        - `read_user`
-        - `openid`
-        - `profile`
-        - `email`
-5. After clicking **Save application** on the GitLab form, you see a summary of the registered application's properties.
-    :::caution
-    Do not click away from this page before copying the **Secret** field.
-    This is the only opportunity you will get to copy the secret.
-    :::
-6. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form on the Ory Console.
-7. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field on the Ory Console.
-8. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+4. [Create a GitLab OAuth2 Application](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile).
+5. Paste the saved **Redirect URI** from Ory into the **Redirect URI** field in the GitLab form.
+6. Enable the relevant **Scopes** for the application, by ticking the relevant boxes in the GitLab form:
     - `read_user`
     - `openid`
     - `profile`
     - `email`
-9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+7. After clicking **Save application** on the GitLab form, you see a summary of the registered application's properties.
+    :::caution
+
+    Make sure to copy the **Secret** field on this summary page right away.
+    This is the only opportunity you will get to copy the secret.
+
+    :::
+
+8. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field on the Ory Console.
+9. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form on the Ory Console.
+10. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `read_user`
+    - `openid`
+    - `profile`
+    - `email`
+11. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
    ```jsonnet
    local claims = {
      email_verified: false,
@@ -59,15 +61,20 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
      },
    }
    ```
+
    :::info
+
    [GitLab](https://docs.gitlab.com/ee/integration/openid_connect_provider.html) returns only the `sub` and `sub_legacy` claims in
    the `id_token`. Ory makes a request to [GitLab's /oauth/userinfo API](https://gitlab.com/oauth/userinfo) and adds the user info
    to `std.extVar('claims')`.
+
    :::
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
-10. Click **Save Configuration**.
+
+12. Click **Save Configuration**.
 
 
 

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -26,7 +26,8 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
     - `openid`
     - `profile`
     - `email`
-7. After clicking **Save application** on the GitLab form, you see a summary of the registered application's properties.
+7. Click **Save application** on the GitLab form, which brings you to a summary of the registered application's properties.
+8. On the summary page, copy the **Secret** field.
 
     :::caution
 

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -4,7 +4,9 @@ title: Add GitLab as a social sign-in provider in Ory
 sidebar_label: GitLab
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # GitLab
 
@@ -28,6 +30,7 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
     - `profile`
     - `email`
 7. After clicking **Save application** on the GitLab form, you see a summary of the registered application's properties.
+
     :::caution
 
     Make sure to copy the **Secret** field on this summary page right away.
@@ -43,6 +46,7 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
     - `profile`
     - `email`
 11. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: false,

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -36,14 +36,15 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 
     :::
 
-8. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field on the Ory Console.
-9. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form on the Ory Console.
-10. In the **Scopes** field of the form on the Ory Console, add the following scopes:
+8. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field in the Ory Console.
+9. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form in the Ory Console.
+10. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `read_user`
     - `openid`
     - `profile`
     - `email`
-11. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+11. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+    which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -6,6 +6,18 @@ sidebar_label: GitLab
 
 # GitLab
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add GitLab as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add GitLab as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a GitLab OAuth2 Application](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile).
@@ -95,3 +107,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -4,6 +4,8 @@ title: Add GitLab as a social sign-in provider in Ory
 sidebar_label: GitLab
 ---
 
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+
 # GitLab
 
 ````mdx-code-block
@@ -14,6 +16,60 @@ import TabItem from '@theme/TabItem';
 <TabItem value="console" label="Ory Console" default>
 
 Follow these steps to add GitLab as a social sign-in provider to your project using the Ory Console:
+
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the GitLab logo to start the configuration.
+3. Copy the Redirect URI and save it for later use.
+4. [Create a GitLab OAuth2 Application](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile),
+  noting the following points:
+    - Paste the saved **Redirect URI** from Ory into the **Redirect URI** field in the GitLab form.
+    - Enable the relevant **Scopes** for the application, by ticking the relevant boxes in the GitLab form:
+        - `read_user`
+        - `openid`
+        - `profile`
+        - `email`
+5. After clicking **Save application** on the GitLab form, you see a summary of the registered application's properties.
+    :::caution
+    Do not click away from this page before copying the **Secret** field.
+    This is the only opportunity you will get to copy the secret.
+    :::
+6. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form on the Ory Console.
+7. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field on the Ory Console.
+8. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `read_user`
+    - `openid`
+    - `profile`
+    - `email`
+9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: false,
+   } + std.extVar('claims');
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // Therefore we only return the email if it (a) exists and (b) is marked verified
+         // by GitLab.
+         [if 'email' in claims && claims.email_verified then 'email' else null]: claims.email,
+       },
+     },
+   }
+   ```
+   :::info
+   [GitLab](https://docs.gitlab.com/ee/integration/openid_connect_provider.html) returns only the `sub` and `sub_legacy` claims in
+   the `id_token`. Ory makes a request to [GitLab's /oauth/userinfo API](https://gitlab.com/oauth/userinfo) and adds the user info
+   to `std.extVar('claims')`.
+   :::
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+10. Click **Save Configuration**.
+
+
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
@@ -57,8 +113,6 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
    :::
 
 ```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
 <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
 ```
 

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -4,13 +4,10 @@ title: Add GitLab as a social sign-in provider in Ory
 sidebar_label: GitLab
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # GitLab
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -23,7 +20,7 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 2. Click the switch next to the GitLab logo to start the configuration.
 3. Copy the Redirect URI and save it for later use.
 4. [Create a GitLab OAuth2 Application](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile).
-5. Paste the saved **Redirect URI** from Ory into the **Redirect URI** field in the GitLab form.
+5. Paste the saved Redirect URI from Ory into the corresponding field in the Gitlab OAuth2 Application configuration.
 6. Enable the relevant **Scopes** for the application, by ticking the relevant boxes in the GitLab form:
     - `read_user`
     - `openid`
@@ -40,7 +37,7 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 
 8. Copy the **Secret** from the registered application in GitLab to the **Client Secret** field on the Ory Console.
 9. Copy the **Application ID** from the registered application in GitLab to the **Client ID** field in the form on the Ory Console.
-10. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+10. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `read_user`
     - `openid`
     - `profile`
@@ -123,9 +120,9 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 
    :::
 
-```mdx-code-block
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/35_gitlab.mdx
+++ b/docs/kratos/social-signin/35_gitlab.mdx
@@ -169,7 +169,7 @@ Follow these steps to add GitLab as a social sign-in provider to your project us
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -4,7 +4,9 @@ title: Add Auth0 as a social sign-in provider in Ory
 sidebar_label: Auth0
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # Auth0
 
@@ -32,6 +34,7 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
     - `profile`
     - `email`
 7. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: false,

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -23,9 +23,10 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
 4. [Create an Auth0 Application for your Auth0 Tenant](https://auth0.com/docs/applications), noting the following points:
     - Choose the application type to be **Regular Web Applications**.
     - Paste the saved **Redirect URI** from Ory into the **Allowed Callback URLs** field in the **Settings** tab of the registered application.
-5. Navigate to the **Settings** tab of the registered application on the Auth0 dashboard and then copy the following data:
-    - Copy the **Client ID** to the corresponding field in the form on the Ory Console.
-    - Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
+5. Navigate to the **Settings** tab of the registered application on the Auth0 dashboard and copy the following data
+   to the corresponding fields in the form on the Ory Console:
+    - **Client ID**
+    - **Client Secret**
 6. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
     - `openid`
     - `profile`
@@ -51,14 +52,19 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
      },
    }
    ```
+
    :::info
+
    [Auth0](https://docs.gitlab.com/ee/integration/openid_connect_provider.html) returns only the `sub` and `sub_legacy` claims in
    the `id_token`. Ory makes a request to [Auth0's /userinfo API](https://auth0.com/docs/api/authentication?http#user-profile) and
    adds the user info to `std.extVar('claims')`.
+
    :::
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
+
 8. Click **Save Configuration**.
 
 

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -4,6 +4,8 @@ title: Add Auth0 as a social sign-in provider in Ory
 sidebar_label: Auth0
 ---
 
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+
 # Auth0
 
 ````mdx-code-block
@@ -14,6 +16,51 @@ import TabItem from '@theme/TabItem';
 <TabItem value="console" label="Ory Console" default>
 
 Follow these steps to add Auth0 as a social sign-in provider to your project using the Ory Console:
+
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the Auth0 logo to start the configuration.
+3. Copy the Redirect URI and save it for later use.
+4. [Create an Auth0 Application for your Auth0 Tenant](https://auth0.com/docs/applications), noting the following points:
+    - Choose the application type to be **Regular Web Applications**.
+    - Paste the saved **Redirect URI** from Ory into the **Allowed Callback URLs** field in the **Settings** tab of the registered application.
+5. Navigate to the **Settings** tab of the registered application on the Auth0 dashboard and then copy the following data:
+    - Copy the **Client ID** to the corresponding field in the form on the Ory Console.
+    - Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
+6. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `openid`
+    - `profile`
+    - `email`
+7. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: false,
+   } + std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // Therefore we only return the email if it (a) exists and (b) is marked verified
+         // by Auth0.
+         [if 'email' in claims && claims.email_verified then 'email' else null]: claims.email,
+         username: claims.nickname,
+       },
+     },
+   }
+   ```
+   :::info
+   [Auth0](https://docs.gitlab.com/ee/integration/openid_connect_provider.html) returns only the `sub` and `sub_legacy` claims in
+   the `id_token`. Ory makes a request to [Auth0's /userinfo API](https://auth0.com/docs/api/authentication?http#user-profile) and
+   adds the user info to `std.extVar('claims')`.
+   :::
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+8. Click **Save Configuration**.
+
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
@@ -59,8 +106,6 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
    :::
 
 ```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
 <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
 ```
 

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -4,13 +4,10 @@ title: Add Auth0 as a social sign-in provider in Ory
 sidebar_label: Auth0
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # Auth0
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -24,12 +21,12 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
 3. Copy the Redirect URI and save it for later use.
 4. [Create an Auth0 Application for your Auth0 Tenant](https://auth0.com/docs/applications), noting the following points:
     - Choose the application type to be **Regular Web Applications**.
-    - Paste the saved **Redirect URI** from Ory into the **Allowed Callback URLs** field in the **Settings** tab of the registered application.
-5. Navigate to the **Settings** tab of the registered application on the Auth0 dashboard and copy the following data
+    - Paste the saved Redirect URI from Ory into the **Allowed Callback URLs** field in the **Settings** tab of the registered application.
+5. Go to the **Settings** tab of the registered application on the Auth0 dashboard and copy the following data
    to the corresponding fields in the form on the Ory Console:
     - **Client ID**
     - **Client Secret**
-6. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+6. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `openid`
     - `profile`
     - `email`
@@ -114,9 +111,9 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
 
    :::
 
-```mdx-code-block
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -159,7 +159,7 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -6,6 +6,18 @@ sidebar_label: Auth0
 
 # Auth0
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Auth0 as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add Auth0 as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create an Auth0 Application for your Auth0 Tenant](https://auth0.com/docs/applications).
@@ -97,3 +109,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/40_auth0.mdx
+++ b/docs/kratos/social-signin/40_auth0.mdx
@@ -23,14 +23,15 @@ Follow these steps to add Auth0 as a social sign-in provider to your project usi
     - Choose the application type to be **Regular Web Applications**.
     - Paste the saved Redirect URI from Ory into the **Allowed Callback URLs** field in the **Settings** tab of the registered application.
 5. Go to the **Settings** tab of the registered application on the Auth0 dashboard and copy the following data
-   to the corresponding fields in the form on the Ory Console:
+   to the corresponding fields in the form in the Ory Console:
     - **Client ID**
     - **Client Secret**
 6. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `openid`
     - `profile`
     - `email`
-7. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+7. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+   which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -15,6 +15,40 @@ import TabItem from '@theme/TabItem';
 
 Follow these steps to add Slack as a social sign-in provider to your project using the Ory Console:
 
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the Slack logo to start the configuration.
+3. Copy the **Redirect URI** and save it for later use.
+4. [Create a Slack OAuth Application](https://api.slack.com/apps) by clicking the **Create New App** button
+5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
+  and add the saved **Redirect URI** from Ory to the **Redirect URLS** of the registered application.
+6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data:
+    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
+    2. Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
+7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `identity.basic`
+    - `identity.email`
+8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: true,
+   } + std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // It's assumed that Slack requires an email to be verified to be accessible
+         // via OAuth (because they don't provide a email_verified field).
+         email: claims.email,
+       },
+     },
+   }
+   ```
+9. Click **Save Configuration**.
+
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
 

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -6,7 +6,19 @@ sidebar_label: Slack
 
 # Slack
 
-Follow these steps to add Spotify as a social sign-in provider to your project using the Ory CLI:
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Slack as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
+Follow these steps to add Slack as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a Slack OAuth Application](https://api.slack.com/apps).
 2. In the created app, set the redirect URI to:
@@ -85,3 +97,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -4,13 +4,10 @@ title: Add Slack as a social sign-in provider in Ory
 sidebar_label: Slack
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # Slack
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -21,15 +18,15 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the Slack logo to start the configuration.
-3. Copy the **Redirect URI** and save it for later use.
+3. Copy the Redirect URI and save it for later use.
 4. [Create a Slack OAuth Application](https://api.slack.com/apps) by clicking the **Create New App** button
 5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
-  and add the saved **Redirect URI** from Ory to the **Redirect URLs** of the registered application.
+  and add the saved Redirect URI from Ory to the **Redirect URLs** of the registered application.
 6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data
    to the corresponding fields in the form on the Ory Console:
     - **Client ID**
     - **Client Secret**
-7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+7. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `identity.basic`
     - `identity.email`
 8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
@@ -93,6 +90,7 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -19,7 +19,7 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the Slack logo to start the configuration.
 3. Copy the Redirect URI and save it for later use.
-4. [Create a Slack OAuth Application](https://api.slack.com/apps) by clicking the **Create New App** button
+4. [Create a Slack OAuth Application](https://api.slack.com/apps).
 5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
   and add the saved Redirect URI from Ory to the **Redirect URLs** of the registered application.
 6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data
@@ -136,7 +136,7 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -4,7 +4,7 @@ title: Add Slack as a social sign-in provider in Ory
 sidebar_label: Slack
 ---
 
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 
 # Slack
 

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -23,13 +23,14 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
   and add the saved Redirect URI from Ory to the **Redirect URLs** of the registered application.
 6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data
-   to the corresponding fields in the form on the Ory Console:
+   to the corresponding fields in the form in the Ory Console:
     - **Client ID**
     - **Client Secret**
-7. In the **Scopes** field of the form on the Ory Console, add the following scopes:
+7. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `identity.basic`
     - `identity.email`
-8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+8. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+   which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -4,6 +4,8 @@ title: Add Slack as a social sign-in provider in Ory
 sidebar_label: Slack
 ---
 
+import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
+
 # Slack
 
 ````mdx-code-block
@@ -20,7 +22,7 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 3. Copy the **Redirect URI** and save it for later use.
 4. [Create a Slack OAuth Application](https://api.slack.com/apps) by clicking the **Create New App** button
 5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
-  and add the saved **Redirect URI** from Ory to the **Redirect URLS** of the registered application.
+  and add the saved **Redirect URI** from Ory to the **Redirect URLs** of the registered application.
 6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data:
     1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
     2. Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
@@ -46,6 +48,9 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
        },
      },
    }
+   ```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
 9. Click **Save Configuration**.
 
@@ -82,12 +87,9 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
      },
    }
    ```
-
-```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -4,7 +4,9 @@ title: Add Slack as a social sign-in provider in Ory
 sidebar_label: Slack
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # Slack
 
@@ -31,6 +33,7 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
     - `identity.basic`
     - `identity.email`
 8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: true,

--- a/docs/kratos/social-signin/45_slack.mdx
+++ b/docs/kratos/social-signin/45_slack.mdx
@@ -23,9 +23,10 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
 4. [Create a Slack OAuth Application](https://api.slack.com/apps) by clicking the **Create New App** button
 5. After creating the new application, navigate to the **OAuth & Permissions** section of the registered application in Slack
   and add the saved **Redirect URI** from Ory to the **Redirect URLs** of the registered application.
-6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data:
-    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
-    2. Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
+6. Navigate to the **Basic Information** section of the registered application in Slack and copy the following data
+   to the corresponding fields in the form on the Ory Console:
+    - **Client ID**
+    - **Client Secret**
 7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
     - `identity.basic`
     - `identity.email`
@@ -49,9 +50,11 @@ Follow these steps to add Slack as a social sign-in provider to your project usi
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
+
 9. Click **Save Configuration**.
 
 </TabItem>

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -6,6 +6,18 @@ sidebar_label: Spotify
 
 # Spotify
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Spotify as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add Spotify as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications).
@@ -87,3 +99,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -4,6 +4,8 @@ title: Add Spotify as a social sign-in provider in Ory
 sidebar_label: Spotify
 ---
 
+import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
+
 # Spotify
 
 ````mdx-code-block
@@ -14,6 +16,36 @@ import TabItem from '@theme/TabItem';
 <TabItem value="console" label="Ory Console" default>
 
 Follow these steps to add Spotify as a social sign-in provider to your project using the Ory Console:
+
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the Spotify logo to start the configuration.
+3. Copy the **Redirect URI** and save it for later use.
+4. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications) by clicking the **CREATE AN APP** button.
+5. From the registered application page in Spotify, copy the following data:
+    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
+    2. Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
+6. From the registered application page in Spotify, click **EDIT SETTINGS** to open the **EDIT SETTINGS** dialog:
+    1. Add the saved **Redirect URI** from Ory to the **Redirect URIs** of the registered application.
+    2. Click **Save** to confirm and close the dialog.
+7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `user-read-email`
+    - `user-read-private`
+8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         email: claims.email,
+       },
+     },
+   }
+   ```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+9. Click **Save Configuration**.
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
@@ -51,8 +83,6 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
    :::
 
 ```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
 <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
 ```
 

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -4,13 +4,10 @@ title: Add Spotify as a social sign-in provider in Ory
 sidebar_label: Spotify
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # Spotify
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -21,16 +18,16 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
 
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the Spotify logo to start the configuration.
-3. Copy the **Redirect URI** and save it for later use.
-4. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications) by clicking the **CREATE AN APP** button.
+3. Copy the Redirect URI and save it for later use.
+4. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications).
 5. From the registered application page in Spotify, copy the following data
    to the corresponding fields in the form on the Ory Console:
     - **Client ID**
     - **Client Secret**
-6. From the registered application page in Spotify, click **EDIT SETTINGS** to open the **EDIT SETTINGS** dialog.
-7. Add the saved **Redirect URI** from Ory to the **Redirect URIs** of the registered application.
+6. From the registered application page in Spotify, click **EDIT SETTINGS**.
+7. Add the saved Redirect URI from Ory to the **Redirect URIs** of the registered application.
 8. Click **Save** to confirm and close the dialog.
-9. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+9. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `user-read-email`
     - `user-read-private`
 10. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
@@ -88,9 +85,9 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
 
    :::
 
-```mdx-code-block
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -4,7 +4,9 @@ title: Add Spotify as a social sign-in provider in Ory
 sidebar_label: Spotify
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # Spotify
 
@@ -32,6 +34,7 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
     - `user-read-email`
     - `user-read-private`
 10. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = std.extVar('claims');
 

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -131,7 +131,7 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -21,16 +21,17 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
 2. Click the switch next to the Spotify logo to start the configuration.
 3. Copy the **Redirect URI** and save it for later use.
 4. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications) by clicking the **CREATE AN APP** button.
-5. From the registered application page in Spotify, copy the following data:
-    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
-    2. Copy the **Client Secret** to the corresponding field in the form on the Ory Console.
-6. From the registered application page in Spotify, click **EDIT SETTINGS** to open the **EDIT SETTINGS** dialog:
-    1. Add the saved **Redirect URI** from Ory to the **Redirect URIs** of the registered application.
-    2. Click **Save** to confirm and close the dialog.
-7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+5. From the registered application page in Spotify, copy the following data
+   to the corresponding fields in the form on the Ory Console:
+    - **Client ID**
+    - **Client Secret**
+6. From the registered application page in Spotify, click **EDIT SETTINGS** to open the **EDIT SETTINGS** dialog.
+7. Add the saved **Redirect URI** from Ory to the **Redirect URIs** of the registered application.
+8. Click **Save** to confirm and close the dialog.
+9. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
     - `user-read-email`
     - `user-read-private`
-8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+10. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
    ```jsonnet
    local claims = std.extVar('claims');
 
@@ -42,10 +43,12 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
-9. Click **Save Configuration**.
+
+11. Click **Save Configuration**.
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -4,7 +4,7 @@ title: Add Spotify as a social sign-in provider in Ory
 sidebar_label: Spotify
 ---
 
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 
 # Spotify
 

--- a/docs/kratos/social-signin/50_spotify.mdx
+++ b/docs/kratos/social-signin/50_spotify.mdx
@@ -21,16 +21,17 @@ Follow these steps to add Spotify as a social sign-in provider to your project u
 3. Copy the Redirect URI and save it for later use.
 4. [Create a Spotify Application](https://developer.spotify.com/dashboard/applications).
 5. From the registered application page in Spotify, copy the following data
-   to the corresponding fields in the form on the Ory Console:
+   to the corresponding fields in the form in the Ory Console:
     - **Client ID**
     - **Client Secret**
 6. From the registered application page in Spotify, click **EDIT SETTINGS**.
 7. Add the saved Redirect URI from Ory to the **Redirect URIs** of the registered application.
 8. Click **Save** to confirm and close the dialog.
-9. In the **Scopes** field of the form on the Ory Console, add the following scopes:
+9. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `user-read-email`
     - `user-read-private`
-10. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+10. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+    which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = std.extVar('claims');

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -24,7 +24,7 @@ Follow these steps to add Discord as a social sign-in provider to your project u
    and copy the following data to the corresponding fields in the form on the Ory Console:
     - **CLIENT ID**
     - **CLIENT SECRET**
-6. From the **OAuth2 | General** section in Discord,
+6. From the **OAuth2 &rarr; General** section in Discord,
    add the saved Redirect URI from Ory to the **Redirects** of the registered application.
 7. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `identify`

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -6,6 +6,18 @@ sidebar_label: Discord
 
 # Discord
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Discord as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add Discord as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a Discord OAuth2 application](https://discord.com/developers/docs/topics/oauth2).
@@ -114,3 +126,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -166,7 +166,7 @@ Follow these steps to add Discord as a social sign-in provider to your project u
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -4,6 +4,8 @@ title: Add Discord as a social sign-in provider in Ory
 sidebar_label: Discord
 ---
 
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+
 # Discord
 
 ````mdx-code-block
@@ -14,6 +16,45 @@ import TabItem from '@theme/TabItem';
 <TabItem value="console" label="Ory Console" default>
 
 Follow these steps to add Discord as a social sign-in provider to your project using the Ory Console:
+
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the Discord logo to start the configuration.
+3. Copy the **Redirect URI** and save it for later use.
+4. [Create a Discord OAuth2 application](https://discord.com/developers/applications) by clicking the **New Application** button.
+5. After creating the application, navigate to the **OAuth2 | General** section of the registered application in Discord
+   and copy the following data:
+    1. Copy the **CLIENT ID** to the corresponding field in the form on the Ory Console.
+    2. Copy the **CLIENT SECRET** to the corresponding field in the form on the Ory Console.
+6. From the **OAuth2 | General** section in Discord,
+   add the saved **Redirect URI** from Ory to the **Redirects** of the registered application.
+7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `identify`
+    - `email`
+8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: false,
+   } + std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // Therefore we only return the email if it (a) exists and (b) is marked verified
+         // by Discord.
+         [if 'email' in claims && claims.email_verified then 'email' else null]: claims.email,
+       },
+     },
+   }
+   ```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+9. Click **Save Configuration**.
+
 
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
@@ -78,8 +119,6 @@ Follow these steps to add Discord as a social sign-in provider to your project u
    :::
 
 ```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
 <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
 ```
 

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -4,7 +4,9 @@ title: Add Discord as a social sign-in provider in Ory
 sidebar_label: Discord
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # Discord
 
@@ -31,6 +33,7 @@ Follow these steps to add Discord as a social sign-in provider to your project u
     - `identify`
     - `email`
 8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: false,

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -22,9 +22,9 @@ Follow these steps to add Discord as a social sign-in provider to your project u
 3. Copy the **Redirect URI** and save it for later use.
 4. [Create a Discord OAuth2 application](https://discord.com/developers/applications) by clicking the **New Application** button.
 5. After creating the application, navigate to the **OAuth2 | General** section of the registered application in Discord
-   and copy the following data:
-    1. Copy the **CLIENT ID** to the corresponding field in the form on the Ory Console.
-    2. Copy the **CLIENT SECRET** to the corresponding field in the form on the Ory Console.
+   and copy the following data to the corresponding fields in the form on the Ory Console:
+    - **CLIENT ID**
+    - **CLIENT SECRET**
 6. From the **OAuth2 | General** section in Discord,
    add the saved **Redirect URI** from Ory to the **Redirects** of the registered application.
 7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
@@ -50,9 +50,11 @@ Follow these steps to add Discord as a social sign-in provider to your project u
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
+
 9. Click **Save Configuration**.
 
 

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -21,15 +21,16 @@ Follow these steps to add Discord as a social sign-in provider to your project u
 3. Copy the Redirect URI and save it for later use.
 4. [Create a Discord OAuth2 application](https://discord.com/developers/applications) by clicking the **New Application** button.
 5. After creating the application, navigate to the **OAuth2 | General** section of the registered application in Discord
-   and copy the following data to the corresponding fields in the form on the Ory Console:
+   and copy the following data to the corresponding fields in the form in the Ory Console:
     - **CLIENT ID**
     - **CLIENT SECRET**
 6. From the **OAuth2 &rarr; General** section in Discord,
    add the saved Redirect URI from Ory to the **Redirects** of the registered application.
-7. In the **Scopes** field of the form on the Ory Console, add the following scopes:
+7. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `identify`
     - `email`
-8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+8. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+   which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {

--- a/docs/kratos/social-signin/55_discord.mdx
+++ b/docs/kratos/social-signin/55_discord.mdx
@@ -4,13 +4,10 @@ title: Add Discord as a social sign-in provider in Ory
 sidebar_label: Discord
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # Discord
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -21,15 +18,15 @@ Follow these steps to add Discord as a social sign-in provider to your project u
 
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the Discord logo to start the configuration.
-3. Copy the **Redirect URI** and save it for later use.
+3. Copy the Redirect URI and save it for later use.
 4. [Create a Discord OAuth2 application](https://discord.com/developers/applications) by clicking the **New Application** button.
 5. After creating the application, navigate to the **OAuth2 | General** section of the registered application in Discord
    and copy the following data to the corresponding fields in the form on the Ory Console:
     - **CLIENT ID**
     - **CLIENT SECRET**
 6. From the **OAuth2 | General** section in Discord,
-   add the saved **Redirect URI** from Ory to the **Redirects** of the registered application.
-7. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+   add the saved Redirect URI from Ory to the **Redirects** of the registered application.
+7. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `identify`
     - `email`
 8. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
@@ -123,9 +120,9 @@ Follow these steps to add Discord as a social sign-in provider to your project u
 
    :::
 
-```mdx-code-block
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/60_twitch.mdx
+++ b/docs/kratos/social-signin/60_twitch.mdx
@@ -100,5 +100,5 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -22,17 +22,18 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 4. Create a [NetID Service](https://developerzone.netid.dev/latest/devportal/tutorial/services/) and
    [NetID Client](https://developerzone.netid.dev/latest/devportal/tutorial/clients/).
 5. Enter the Redirect URI you copied from Ory to the **Callback URL** field of the NetID Client.
-6. After creating the NetID Client, the client is initially in _sandbox mode_, which is a pre-production state
+6. After creating the NetID Client, the client is initially in sandbox mode, which is a pre-production state
    prior to the release of your NetID Service.
    If you want to test your NetID Client while it is in sandbox mode, you need to create one or more test users,
    by going to the NetID Service page and clicking **Add test user**.
-7. Copy the following data from the NetID Client settings to the corresponding fields in the form on the Ory Console:
+7. Copy the following data from the NetID Client settings to the corresponding fields in the form in the Ory Console:
     - **Client ID**
     - **Client secret** (sandbox or live, depending on the status of the NetID Service)
-8. In the **Scopes** field of the form on the Ory Console, add the following scopes:
+8. In the **Scopes** field of the form in the Ory Console, add the following scopes:
     - `openid`
     - `email`
-9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+9. In the **Data Mapping** field of the form in the Ory Console, add the following Jsonnet code snippet,
+   which maps the desired claims to the Ory Identity schema:
 
    ```jsonnet
    local claims = {
@@ -68,13 +69,17 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 
 1. Create a [NetID Service](https://developerzone.netid.dev/latest/devportal/tutorial/services/) and
    [NetID Client](https://developerzone.netid.dev/latest/devportal/tutorial/clients/).
-2. In the created app, set the redirect URI to:
+2. After creating the NetID Client, the client is initially in sandbox mode, which is a pre-production state
+   prior to the release of your NetID Service.
+   If you want to test your NetID Client while it is in sandbox mode, you need to create one or more test users,
+   by going to the NetID Service page and clicking **Add test user**.
+3. In the created app, set the redirect URI to:
 
    ```shell
    https://{project.slug}.projects.oryapis.com/self-service/methods/oidc/callback/netid
    ```
 
-3. Create a Jsonnet code snippet to map the desired claims to the Ory Identity schema.
+4. Create a Jsonnet code snippet to map the desired claims to the Ory Identity schema.
 
    ```jsonnet
    local claims = {
@@ -108,13 +113,13 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
 
-4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
+5. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 
    ```shell
    cat your-data-mapping.jsonnet | base64
    ```
 
-5. Download the Ory Identities config from your project and save it to a file:
+6. Download the Ory Identities config from your project and save it to a file:
 
    ```shell
    ## List all available projects
@@ -124,7 +129,7 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
    ory get identity-config {project-id} --format yaml > identity-config.yaml
    ```
 
-6. Add the social sign-in provider configuration to the downloaded config. Add the Jsonnet snippet with mappings as a Base64
+7. Add the social sign-in provider configuration to the downloaded config. Add the Jsonnet snippet with mappings as a Base64
    string or provide an URL to the file.
 
    ```yaml
@@ -157,7 +162,7 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
          enabled: true
    ```
 
-7. Update the Ory Identities configuration using the file you worked with:
+8. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -4,6 +4,8 @@ title: Add NetID as a social sign-in provider in Ory
 sidebar_label: NetID
 ---
 
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+
 # NetID
 
 ````mdx-code-block
@@ -15,13 +17,53 @@ import TabItem from '@theme/TabItem';
 
 Follow these steps to add NetID as a social sign-in provider to your project using the Ory Console:
 
+1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
+2. Click the switch next to the NetID logo to start the configuration.
+3. Copy the **Redirect URI** and save it for later use.
+4. Create a [NetID Service](https://developerzone.netid.dev/latest/devportal/tutorial/services/) and
+   [NetID Client](https://developerzone.netid.dev/latest/devportal/tutorial/clients/).
+5. While creating the NetID Client, enter the saved **Redirect URI** from Ory to the **Callback URL** field of the NetID Client.
+6. After creating the NetID Client, the client is initially in sandbox mode, where only specified test user email addresses can use OAuth login.
+To enable an email address for OAuth, go to the NetID Service page and click **Add test user**.
+7. Copy the following data from the NetID Client settings:
+    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
+    2. Copy the **Client secret** (sandbox or live, depending on the status of the NetID Service) to the corresponding field in the form on the Ory Console.
+8. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+    - `openid`
+    - `email`
+9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+   ```jsonnet
+   local claims = {
+     email_verified: false
+   } + std.extVar('claims');
+
+   {
+     identity: {
+       traits: {
+         // Allowing unverified email addresses enables account
+         // enumeration attacks,  if the value is used for
+         // verification or as a password login identifier.
+         //
+         // Therefore we only return the email if it (a) exists and (b) is marked verified
+         // by NetID.
+         [if "email" in claims && claims.email_verified then "email" else null]: claims.email,
+       },
+     },
+   }
+   ```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
+10. Click **Save Configuration**.
+
+
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
 
 Follow these steps to add NetID as a social sign-in provider to your project using the Ory CLI:
 
-1. Create a [NetID Service](https://developerzone.netid.dev/devportal/tutorial/services/) and
-   [NetID Client](https://developerzone.netid.dev/devportal/tutorial/clients/).
+1. Create a [NetID Service](https://developerzone.netid.dev/latest/devportal/tutorial/services/) and
+   [NetID Client](https://developerzone.netid.dev/latest/devportal/tutorial/clients/).
 2. In the created app, set the redirect URI to:
 
    ```shell
@@ -59,8 +101,6 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
    :::
 
 ```mdx-code-block
-import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
-
 <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
 ```
 

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -6,6 +6,18 @@ sidebar_label: NetID
 
 # NetID
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add NetID as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add NetID as a social sign-in provider to your project using the Ory CLI:
 
 1. Create a [NetID Service](https://developerzone.netid.dev/devportal/tutorial/services/) and
@@ -106,3 +118,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -4,13 +4,10 @@ title: Add NetID as a social sign-in provider in Ory
 sidebar_label: NetID
 ---
 
-```mdx-code-block
-import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
-```
-
 # NetID
 
 ````mdx-code-block
+import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -21,16 +18,18 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 
 1. Sign in to Ory Console and select [**Social Sign-in**](https://console.ory.sh/projects/current/social-signin).
 2. Click the switch next to the NetID logo to start the configuration.
-3. Copy the **Redirect URI** and save it for later use.
+3. Copy the Redirect URI and save it for later use.
 4. Create a [NetID Service](https://developerzone.netid.dev/latest/devportal/tutorial/services/) and
    [NetID Client](https://developerzone.netid.dev/latest/devportal/tutorial/clients/).
-5. While creating the NetID Client, enter the saved **Redirect URI** from Ory to the **Callback URL** field of the NetID Client.
-6. After creating the NetID Client, the client is initially in sandbox mode, where only specified test user email addresses can use OAuth login.
-To enable an email address for OAuth, go to the NetID Service page and click **Add test user**.
+5. Enter the Redirect URI you copied from Ory to the **Callback URL** field of the NetID Client.
+6. After creating the NetID Client, the client is initially in _sandbox mode_, which is a pre-production state
+   prior to the release of your NetID Service.
+   If you want to test your NetID Client while it is in sandbox mode, you need to create one or more test users,
+   by going to the NetID Service page and clicking **Add test user**.
 7. Copy the following data from the NetID Client settings to the corresponding fields in the form on the Ory Console:
     - **Client ID**
     - **Client secret** (sandbox or live, depending on the status of the NetID Service)
-8. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
+8. In the **Scopes** field of the form on the Ory Console, add the following scopes:
     - `openid`
     - `email`
 9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
@@ -105,9 +104,9 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 
    :::
 
-```mdx-code-block
-<JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
-```
+   ```mdx-code-block
+   <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
+   ```
 
 4. Encode the Jsonnet snippet with [Base64](https://www.base64encode.org/) or host it under an URL accessible to The Ory Network.
 

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -25,9 +25,9 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 5. While creating the NetID Client, enter the saved **Redirect URI** from Ory to the **Callback URL** field of the NetID Client.
 6. After creating the NetID Client, the client is initially in sandbox mode, where only specified test user email addresses can use OAuth login.
 To enable an email address for OAuth, go to the NetID Service page and click **Add test user**.
-7. Copy the following data from the NetID Client settings:
-    1. Copy the **Client ID** to the corresponding field in the form on the Ory Console.
-    2. Copy the **Client secret** (sandbox or live, depending on the status of the NetID Service) to the corresponding field in the form on the Ory Console.
+7. Copy the following data from the NetID Client settings to the corresponding fields in the form on the Ory Console:
+    - **Client ID**
+    - **Client secret** (sandbox or live, depending on the status of the NetID Service)
 8. In the **Scopes** field of the form on the Ory Console, add the following scopes (one by one):
     - `openid`
     - `email`
@@ -51,9 +51,11 @@ To enable an email address for OAuth, go to the NetID Service page and click **A
      },
    }
    ```
+
    ```mdx-code-block
    <JsonnetWarning format="Jsonnet code snippets" use="data mapping" />
    ```
+
 10. Click **Save Configuration**.
 
 

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -4,7 +4,9 @@ title: Add NetID as a social sign-in provider in Ory
 sidebar_label: NetID
 ---
 
+```mdx-code-block
 import JsonnetWarning from "../../_common/jsonnetwarning.mdx"
+```
 
 # NetID
 
@@ -32,6 +34,7 @@ To enable an email address for OAuth, go to the NetID Service page and click **A
     - `openid`
     - `email`
 9. In the **Data Mapping** field of the form on the Ory Console, add the following Jsonnet code snippet:
+
    ```jsonnet
    local claims = {
      email_verified: false

--- a/docs/kratos/social-signin/65_netid.mdx
+++ b/docs/kratos/social-signin/65_netid.mdx
@@ -61,7 +61,6 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 
 10. Click **Save Configuration**.
 
-
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
 
@@ -165,7 +164,7 @@ Follow these steps to add NetID as a social sign-in provider to your project usi
 8. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```
 
 </TabItem>

--- a/docs/kratos/social-signin/70_yandex.mdx
+++ b/docs/kratos/social-signin/70_yandex.mdx
@@ -6,6 +6,18 @@ sidebar_label: Yandex
 
 # Yandex
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add Yandex as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add Yandex as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a Yandex OAuth2 Application](https://yandex.com/dev/oauth/doc/dg/tasks/register-client.html).
@@ -85,3 +97,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/70_yandex.mdx
+++ b/docs/kratos/social-signin/70_yandex.mdx
@@ -83,5 +83,5 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```

--- a/docs/kratos/social-signin/70_yandex.mdx
+++ b/docs/kratos/social-signin/70_yandex.mdx
@@ -6,18 +6,6 @@ sidebar_label: Yandex
 
 # Yandex
 
-````mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs>
-<TabItem value="console" label="Ory Console" default>
-
-Follow these steps to add Yandex as a social sign-in provider to your project using the Ory Console:
-
-</TabItem>
-<TabItem value="cli" label="Ory CLI">
-
 Follow these steps to add Yandex as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a Yandex OAuth2 Application](https://yandex.com/dev/oauth/doc/dg/tasks/register-client.html).
@@ -97,7 +85,3 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
-
-</TabItem>
-</Tabs>
-````

--- a/docs/kratos/social-signin/75_vk.mdx
+++ b/docs/kratos/social-signin/75_vk.mdx
@@ -6,7 +6,19 @@ sidebar_label: VKontakte
 
 # VKontakte
 
-Follow these steps to add Twitch as a social sign-in provider to your project using the Ory CLI:
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add VKontakte as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
+Follow these steps to add VKontakte as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a VK OAuth2 Application](https://vk.com/apps?act=manage).
 2. In the created app, set the redirect URI to:
@@ -86,3 +98,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/75_vk.mdx
+++ b/docs/kratos/social-signin/75_vk.mdx
@@ -84,5 +84,5 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```

--- a/docs/kratos/social-signin/75_vk.mdx
+++ b/docs/kratos/social-signin/75_vk.mdx
@@ -6,19 +6,7 @@ sidebar_label: VKontakte
 
 # VKontakte
 
-````mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs>
-<TabItem value="console" label="Ory Console" default>
-
-Follow these steps to add VKontakte as a social sign-in provider to your project using the Ory Console:
-
-</TabItem>
-<TabItem value="cli" label="Ory CLI">
-
-Follow these steps to add VKontakte as a social sign-in provider to your project using the Ory CLI:
+Follow these steps to add Twitch as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a VK OAuth2 Application](https://vk.com/apps?act=manage).
 2. In the created app, set the redirect URI to:
@@ -98,7 +86,3 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
-
-</TabItem>
-</Tabs>
-````

--- a/docs/kratos/social-signin/80_dingtalk.mdx
+++ b/docs/kratos/social-signin/80_dingtalk.mdx
@@ -6,6 +6,18 @@ sidebar_label: DingTalk
 
 # DingTalk
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="console" label="Ory Console" default>
+
+Follow these steps to add DingTalk as a social sign-in provider to your project using the Ory Console:
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
 Follow these steps to add DingTalk as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a DingTalk OAuth app](https://open-dev.dingtalk.com/fe/app#/corp/app).
@@ -90,3 +102,7 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
+
+</TabItem>
+</Tabs>
+````

--- a/docs/kratos/social-signin/80_dingtalk.mdx
+++ b/docs/kratos/social-signin/80_dingtalk.mdx
@@ -6,18 +6,6 @@ sidebar_label: DingTalk
 
 # DingTalk
 
-````mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs>
-<TabItem value="console" label="Ory Console" default>
-
-Follow these steps to add DingTalk as a social sign-in provider to your project using the Ory Console:
-
-</TabItem>
-<TabItem value="cli" label="Ory CLI">
-
 Follow these steps to add DingTalk as a social sign-in provider to your project using the Ory CLI:
 
 1. [Create a DingTalk OAuth app](https://open-dev.dingtalk.com/fe/app#/corp/app).
@@ -102,7 +90,3 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
    ```shell
    ory update identity-config {project-id} --file updated_config.yaml
    ```
-
-</TabItem>
-</Tabs>
-````

--- a/docs/kratos/social-signin/80_dingtalk.mdx
+++ b/docs/kratos/social-signin/80_dingtalk.mdx
@@ -88,5 +88,5 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```

--- a/docs/kratos/social-signin/81_lark.mdx
+++ b/docs/kratos/social-signin/81_lark.mdx
@@ -82,5 +82,5 @@ import JsonnetWarning from '../../_common/jsonnetwarning.mdx'
 7. Update the Ory Identities configuration using the file you worked with:
 
    ```shell
-   ory update identity-config {project-id} --file updated_config.yaml
+   ory update identity-config {project-id} --file identity-config.yaml
    ```


### PR DESCRIPTION
Ory Console has recently added support for several new social sign-in providers, which are not yet documented. This PR adds a new **Ory Console** tab to the docs for each of these providers, giving the instructions to enable the provider in the Ory Console

## Related Issue or Design Document

Issue is https://github.com/ory-corp/cloud/issues/3726

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
