### PR TITLE
feat: enable syntax highlighting for relationtuples and relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ slug: excellent-feature-for-some-reason
   ```
   ````
 
-- For Ory Permission (Keto) relation-tuples, use the `keto-relation-tuples` language, and for the new relationships, use the `keto-relationships` language.
+- For Ory Permission (Keto) relation-tuples, use the `keto-relation-tuples`
+  language, and for the new relationships, use the `keto-relationships`
+  language.
 
   ````
   ```keto-relation-tuples

--- a/README.md
+++ b/README.md
@@ -212,6 +212,21 @@ slug: excellent-feature-for-some-reason
   ```
   ````
 
+- For Ory Permission (Keto) relation-tuples, use the `keto-relation-tuples` language, and for the new relationships, use the `keto-relationships` language.
+
+  ````
+  ```keto-relation-tuples
+  namespace:object#relation:subject
+  // comment
+  ```
+
+  ```keto-relationships
+  namespace:subject is relation of object
+  is namespace:subject allowed to permission on object?
+  // comment
+  ```
+  ````
+
 ### Placeholders and dummy data
 
 Using placeholders and dummy data in code snippets and command examples is a

--- a/src/theme/ketoRelationsPermissionsPrism.js
+++ b/src/theme/ketoRelationsPermissionsPrism.js
@@ -1,0 +1,76 @@
+// Copyright © 2022 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+const namespace = {
+  pattern: /[a-zA-Z0-9-_]+:/,
+  inside: {
+    delimiter: /:/,
+    namespace: /[a-zA-Z0-9-_]+/,
+  },
+}
+
+const object = {
+  pattern: /[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
+  inside: {
+    namespace,
+    id: /.*/, // everything else that is not the namespace
+  },
+}
+
+const relation = {
+  pattern: /[a-zA-Z0-9-_]+ of /,
+  inside: {
+    delimiter: / of /,
+  },
+}
+
+const relationAndObject = {
+  pattern: /[a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
+  inside: {
+    relation,
+    object,
+  },
+}
+
+const relationSubject = {
+  pattern: /\(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is /,
+  inside: {
+    delimiter: /( is )|[()]/,
+    // we first try to match relationAndObject, if that fails we match object
+    "": relationAndObject,
+    object,
+  },
+}
+
+const permissionSubject = {
+  pattern: /is \(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)?/,
+  inside: {
+    delimiter: /(is )|[()]/,
+    // we first try to match relationAndObject, if that fails we match object
+    "": relationAndObject,
+    object,
+  },
+}
+
+export default (prism) => {
+  prism.languages["keto-relationships"] = {
+    comment: /\/\/.*(\n|$)/,
+    relationship: {
+      pattern:
+        /\(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is [a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
+      inside: {
+        subject: relationSubject,
+        "": relationAndObject,
+      },
+    },
+    "permission-question": {
+      pattern:
+        /is \(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? allowed to [a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\??/,
+      inside: {
+        delimiter: /( allowed to )|\?/,
+        subject: permissionSubject,
+        "": relationAndObject,
+      },
+    },
+  }
+}

--- a/src/theme/ketoRelationsPermissionsPrism.js
+++ b/src/theme/ketoRelationsPermissionsPrism.js
@@ -18,14 +18,14 @@ const object = {
 }
 
 const relation = {
-  pattern: /[a-zA-Z0-9-_]+ of /,
+  pattern: /[a-zA-Z0-9-_]+ o[fn] /,
   inside: {
-    delimiter: / of /,
+    delimiter: / o[fn] /,
   },
 }
 
 const relationAndObject = {
-  pattern: /[a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
+  pattern: /[a-zA-Z0-9-_]+ o[fn] [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
   inside: {
     relation,
     object,
@@ -33,7 +33,7 @@ const relationAndObject = {
 }
 
 const relationSubject = {
-  pattern: /\(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is /,
+  pattern: /\(?([a-zA-Z0-9-_]+ o[fn] )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is /,
   inside: {
     delimiter: /( is )|[()]/,
     // we first try to match relationAndObject, if that fails we match object
@@ -43,7 +43,7 @@ const relationSubject = {
 }
 
 const permissionSubject = {
-  pattern: /is \(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)?/,
+  pattern: /is \(?([a-zA-Z0-9-_]+ o[fn] )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)?/,
   inside: {
     delimiter: /(is )|[()]/,
     // we first try to match relationAndObject, if that fails we match object
@@ -57,7 +57,7 @@ export default (prism) => {
     comment: /\/\/.*(\n|$)/,
     relationship: {
       pattern:
-        /\(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is [a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
+        /\(?([a-zA-Z0-9-_]+ o[fn] )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? is [a-zA-Z0-9-_]+ o[fn] [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+/,
       inside: {
         subject: relationSubject,
         "": relationAndObject,
@@ -65,7 +65,7 @@ export default (prism) => {
     },
     "permission-question": {
       pattern:
-        /is \(?([a-zA-Z0-9-_]+ of )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? allowed to [a-zA-Z0-9-_]+ of [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\??/,
+        /is \(?([a-zA-Z0-9-_]+ o[fn] )?[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\)? allowed to [a-zA-Z0-9-_]+ o[fn] [a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+\??/,
       inside: {
         delimiter: /( allowed to )|\?/,
         subject: permissionSubject,

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -4,6 +4,7 @@
 import siteConfig from "@generated/docusaurus.config"
 
 import ketoRelationTuplesPrism from "./ketoRelationTuplesPrism"
+import ketoRelationsPermissionsPrism from "./ketoRelationsPermissionsPrism"
 export default function prismIncludeLanguages(PrismObject) {
   const {
     themeConfig: { prism },
@@ -21,5 +22,6 @@ export default function prismIncludeLanguages(PrismObject) {
   })
 
   ketoRelationTuplesPrism(PrismObject)
+  ketoRelationsPermissionsPrism(PrismObject)
   delete globalThis.Prism
 }

--- a/src/utils/prismLight.mjs
+++ b/src/utils/prismLight.mjs
@@ -7,49 +7,6 @@
 
 import lightTheme from "prism-react-renderer/themes/github/index.cjs.js"
 
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["namespace"],
-//       style: {
-//         color: "#666",
-//       },
-//     },
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["object"],
-//       style: {
-//         color: "#939",
-//       },
-//     },
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["relation"],
-//       style: {
-//         color: "#e80",
-//       },
-//     },
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["delimiter"],
-//       style: {
-//         color: "#555",
-//       },
-//     },
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["comment"],
-//       style: {
-//         color: "#999",
-//       },
-//     },
-//     {
-//       languages: ["keto-relation-tuples"],
-//       types: ["subject"],
-//       style: {
-//         color: "#903",
-//       },
-//     },
-
 export default {
   ...lightTheme,
   styles: [
@@ -137,6 +94,48 @@ export default {
       types: ["comment"],
       style: {
         color: "#6B6B6B",
+      },
+    },
+    {
+      languages: ["keto-relation-tuples", "keto-relationships"],
+      types: ["namespace"],
+      style: {
+        color: "#666",
+      },
+    },
+    {
+      languages: ["keto-relation-tuples"],
+      types: ["object"],
+      style: {
+        color: "#939",
+      },
+    },
+    {
+      languages: ["keto-relation-tuples", "keto-relationships"],
+      types: ["relation"],
+      style: {
+        color: "#e80",
+      },
+    },
+    {
+      languages: ["keto-relation-tuples", "keto-relationships"],
+      types: ["delimiter"],
+      style: {
+        color: "#555",
+      },
+    },
+    {
+      languages: ["keto-relation-tuples"],
+      types: ["subject"],
+      style: {
+        color: "#903",
+      },
+    },
+    {
+      languages: ["keto-relationships"],
+      types: ["id"],
+      style: {
+        color: "#939",
       },
     },
   ],


### PR DESCRIPTION
This adds a new language to represent the new relationship string format, as well as re-enables syntax highlighting for the current relation tuples.

![image](https://user-images.githubusercontent.com/5354445/213203323-897c0355-2c8c-486d-81dd-206ffb7ec9ce.png)
![image](https://user-images.githubusercontent.com/5354445/213203398-ebf876d1-3640-4951-bcf9-17b2a9d5a1f9.png)
