### PR TITLE
fix: secure admonition

### DIFF
--- a/docs/_common/secure.mdx
+++ b/docs/_common/secure.mdx
@@ -6,4 +6,6 @@ considered authenticated, authorized, and will be executed. Leaving the APIs in 
 When deploying Ory open-source Servers, protect access to their APIs using [Ory Oathkeeper](https://github.com/ory/oathkeeper) or
 a comparable API Gateway.
 
-If you need help, reach out to the community on [Ory Community Slack](http://slack.ory.sh/). :::
+If you need help, reach out to the community on [Ory Community Slack](http://slack.ory.sh/).
+
+:::


### PR DESCRIPTION
fixes the "secure" admonition from this PR https://github.com/ory/docs/pull/1252/

Sorry should not have merged before checking that it actually renders correctly. 
Should be fine now. 

PTAL @tomekpapiernik 