### PR TITLE
fix: actions configuration

### DIFF
--- a/docs/guides/integrate-with-ory-cloud-through-webhooks.mdx
+++ b/docs/guides/integrate-with-ory-cloud-through-webhooks.mdx
@@ -81,7 +81,7 @@ selfservice:
       after:
         hooks: [] # These acions are executed only if no more specific hooks in the `password` or `oidc` sections are defined
         password:
-          # Actions in this sections will be executed after sign up (or login, settings) with password
+          # Actions in this section will be executed after registration (or login, settings) with a password
           hooks:
             - hook: web_hook
               config:
@@ -96,7 +96,7 @@ selfservice:
             - hook: session # see https://www.ory.sh/docs/actions/session
         oidc:
           hooks:
-            # Actions in this section will be executed after sign up (or login, settings) with a social sign-in provider / OpenID Connect
+            # Actions in this section will be executed after registration (or login, settings) with a social sign-in provider / OpenID Connect
             # ...
 # highlight-end
 ```

--- a/docs/guides/integrate-with-ory-cloud-through-webhooks.mdx
+++ b/docs/guides/integrate-with-ory-cloud-through-webhooks.mdx
@@ -79,23 +79,23 @@ selfservice:
   flows:
     registration: # or login, recovery, verification, settings
       after:
-        hooks:
-          - hook: web_hook
-            config:
-              url: https://webhook.traget/example
-              method: POST
-              body: base64://ey...
-              response:
-                ignore: false
-                parse: false
-              auth:
-                # ...
+        hooks: [] # These acions are executed only if no more specific hooks in the `password` or `oidc` sections are defined
         password:
-          after:
-            # Actions in this sections will be executed after sign up (or login, settings) with password
-            # ...
+          # Actions in this sections will be executed after sign up (or login, settings) with password
+          hooks:
+            - hook: web_hook
+              config:
+                url: https://webhook.target/example
+                method: POST
+                body: base64://ey...
+                response:
+                  ignore: false
+                  parse: false
+                auth:
+                  # ...
+            - hook: session # see https://www.ory.sh/docs/actions/session
         oidc:
-          after:
+          hooks:
             # Actions in this section will be executed after sign up (or login, settings) with a social sign-in provider / OpenID Connect
             # ...
 # highlight-end
@@ -105,8 +105,7 @@ selfservice:
 
 ```shell
 ory update identity-config {project-id} \
-  --file project-configuration.yaml \
-  --format yaml > project-configuration.yaml
+  --file project-configuration.yaml
 ```
 
 ```mdx-code-block


### PR DESCRIPTION
The `flows.registration.after.hooks` section is used only if the `flows.registration.after.{password,oidc}` sections are empty.

This was confusing to users, because by default we have the `session` hook in this section, which would then case the webhooks in the "global" section to not be sent.