### PR TITLE
docs: replace link to localhost host with link to documentation site

### DIFF
--- a/docs/keto/sdk/05_go.mdx
+++ b/docs/keto/sdk/05_go.mdx
@@ -228,4 +228,4 @@ func main() {
 
 ## More examples gRPC API
 
-- [Protocol Buffer API](http://localhost:3001/docs/keto/reference/proto-api)
+- [Protocol Buffer API](https://www.ory.sh/docs/keto/reference/proto-api)


### PR DESCRIPTION
Updating a link in the documentation that was pointing to localhost

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).