### PR TITLE
Revert "docs: clarify the need for __cflb cookie" - don't merge yet

### DIFF
--- a/docs/concepts/cache.mdx
+++ b/docs/concepts/cache.mdx
@@ -32,15 +32,6 @@ The caching strategy is as follows:
 - If the session credentials are known and cached, the cache respects the `Cache-Control: max-age=60` header.
 - If the user updates their profile or adds another authentication factor, the session is refreshed in the cache automatically.
 
-The cache will respond with `CF-Cache-Status: Hit` if a cached response is served.
-
-:::caution
-
-Pass the `__cflb` cookie when you call the `/sessions/whoami` endpoint. If you don't pass the `__cflb`, you get a lot of cache
-misses.
-
-:::
-
 ## Performance
 
 You can expect a P95 latency of ~60ms and a P99 latency of ~70ms across the globe when you use edge sessions. Results can vary

--- a/docs/identities/sign-in/check-session.mdx
+++ b/docs/identities/sign-in/check-session.mdx
@@ -37,13 +37,6 @@ and the session payload.
 
 When using the SDK, use the `frontend.toSession()` method.
 
-:::caution
-
-You must pass the `__cflb` cookie with the Ory Session Cookie in your requests to leverage the benefits of
-[Edge Sessions](../../concepts/cache.mdx) and serve `/sessions/whoami` checks with 40ms latency.
-
-:::
-
 ````mdx-code-block
 <Tabs>
 <TabItem value="curl" label="cURL" default>
@@ -58,7 +51,7 @@ curl -H "Authorization: Bearer {your-session-token}" \
 To check for an active session with an Ory Session Cookie, run:
 
 ```shell
-curl -H "Cookie: ory_session_...=...; __cflb=..." \
+curl -H "Cookie: ory_session_...=..." \
   "https://{project.slug}.projects.oryapis.com/sessions/whoami"
 ```
 


### PR DESCRIPTION
Reverts ory/docs#1283

We identified the root cause of the behavior, and it is no longer needed to include this cookie.

DO NOT MERGE