### PR TITLE
Remove deprecated --id option

### DIFF
--- a/docs/hydra/cli/hydra-clients-create.md
+++ b/docs/hydra/cli/hydra-clients-create.md
@@ -45,7 +45,6 @@ hydra create client [flags]
       --frontchannel-logout-session-required     Boolean flag specifying whether the client requires that a sid (session ID) Claim be included in the Logout Token to identify the client session with the OP when the frontchannel-logout-callback is used. If omitted, the default value is false.
   -g, --grant-type strings                      A list of allowed grant types (default [authorization_code])
   -h, --help                                     help for create
-      --id string                                Give the client this id
       --jwks-uri string                          Define the URL where the JSON Web Key Set should be fetched from when performing the "private_key_jwt" client authentication method
       --keybase string                           Keybase username for encrypting client secret
       --logo-uri string                          A URL string that references a logo for the client


### PR DESCRIPTION
Setting the client id is not possible anymore (https://github.com/ory/hydra/issues/2911), but the --id option was still in the docs.

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.

I'm not going to read through pages of legal lingo and am not going to sign anything to remove a deprecated line of documentation. Replicate the change with your own PR if you can't merge it like that.
