### PR TITLE
fix: add oathkeeper obs port

### DIFF
--- a/docs/self-hosted/operations/15_observability.md
+++ b/docs/self-hosted/operations/15_observability.md
@@ -5,10 +5,10 @@ title: Observability
 
 ## Prometheus
 
-All Ory services expose an endpoint for snapshots of data collected by Prometheus. This endpoint is found at the administrative
-port for Ory Kratos, at the `/metrics/prometheus` path for Ory Hydra and Ory Keto. If you run the default configuration, it will
-be exposed at:
+All Ory services expose an endpoint for snapshots of data collected by Prometheus. This endpoint is found at `/metrics/prometheus`
+for all projects. If you run the default configuration, it will be exposed at:
 
 - Ory Kratos: `http://{host}:4434/metrics/prometheus`
 - Ory Hydra: `http://{host}:4445/metrics/prometheus`
 - Ory Keto: `http://{host}:4468/metrics/prometheus`
+- Ory Oathkeeper `http://{host}:9000/metrics/prometheus`


### PR DESCRIPTION
Forgot to add the Oathkeeper port in my previous PR. 
Also words the sentence less confusing, they all have the same endpoint but different ports in the default configuration.