### PR TITLE
docs: make Ory logo link to website, and remove obsolete Website link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ const config = {
         alt: "Ory",
         src: `/docs/img/logo-docs.svg`,
         srcDark: `/docs/img/logo-docs-dark.svg`,
-        href: `https://www.ory.sh/docs`,
+        href: `https://www.ory.sh`,
       },
       items: [
         {
@@ -104,11 +104,6 @@ const config = {
           position: "left",
           sidebarId: "selfhosting",
           label: "Self-hosting",
-        },
-        {
-          to: "https://www.ory.sh/",
-          label: `Website`,
-          position: "right",
         },
         {
           href: `https://github.com/ory/cloud/discussions`,


### PR DESCRIPTION
Implements the universal convention whereby the company logo in the top right of the page brings you to the main corporate web site. This also makes the "Website" link on the navbar redundant.