### PR TITLE
Fix typo Authkeeper -> Oathkeeper

### DIFF
--- a/docs/oathkeeper/index.md
+++ b/docs/oathkeeper/index.md
@@ -94,7 +94,7 @@ The response of this request will then be sent to the client that made the reque
 ### Access Control Decision API
 
 The Ory Oathkeeper Access Control Decision API follows best-practices and works with most (if not all) modern API gateways and
-reverse proxies. To verify a request, send it to the `decisions` endpoint located at the Ory Authkeeper API port. It matches every
+reverse proxies. To verify a request, send it to the `decisions` endpoint located at the Ory Oathkeeper API port. It matches every
 sub-path and HTTP Method:
 
 - `GET /decisions/v1/api`


### PR DESCRIPTION
There is a typo in Oathkeeper introduction documentation: https://www.ory.sh/docs/oathkeeper/

> To verify a request, send it to the decisions endpoint located at the Ory **Authkeeper** API port.
Highlighted word should be Oathkeeper, not Authkeeper.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
