### PR TITLE
fix: split up custom ui examples

### DIFF
--- a/docs/getting-started/custom-ui.mdx
+++ b/docs/getting-started/custom-ui.mdx
@@ -1,15 +1,13 @@
 ---
-id: overview
-title: Overview
+id: custom-ui
+title: Custom UI Examples
 ---
 
-Are you looking for an example to just get started? Check out all available examples!
+Are you looking for an example to build a custom UI? Fork the pre-built user interfaces!
 
 ```mdx-code-block
 import ExampleList from "@site/src/components/Examples/example-list"
 import * as content from "@site/src/pages/_assets/examples-content"
 
-<ExampleList {...content.basic} />
 <ExampleList {...content.customui} />
-<ExampleList {...content.community} />
 ```

--- a/docs/getting-started/custom-ui.mdx
+++ b/docs/getting-started/custom-ui.mdx
@@ -3,7 +3,11 @@ id: custom-ui
 title: Custom UI
 ---
 
-Are you looking for an example on how to build a custom user interface for Ory Identities? Fork the pre-built user interfaces!
+Are you looking for an example on how to build a custom user interface for Ory Identities or the Ory Kratos Identity Server? Fork
+these pre-built user interfaces!
+
+It is recommended to read the [custom user interface documentation](../kratos/bring-your-own-ui/01_overview.mdx) before you start
+coding.
 
 ```mdx-code-block
 import ExampleList from "@site/src/components/Examples/example-list"

--- a/docs/getting-started/custom-ui.mdx
+++ b/docs/getting-started/custom-ui.mdx
@@ -1,9 +1,9 @@
 ---
 id: custom-ui
-title: Custom UI Examples
+title: Custom UI
 ---
 
-Are you looking for an example to build a custom UI? Fork the pre-built user interfaces!
+Are you looking for an example on how to build a custom user interface for Ory Identities? Fork the pre-built user interfaces!
 
 ```mdx-code-block
 import ExampleList from "@site/src/components/Examples/example-list"

--- a/docs/kratos/bring-your-own-ui/01_overview.mdx
+++ b/docs/kratos/bring-your-own-ui/01_overview.mdx
@@ -51,5 +51,8 @@ To learn how to use Ory Elements and see a sample implementation, read
 
 ## Next steps
 
-To understand the fundamentals Ory APIs and learn how to interact with them in your UI, take a look at the
-[Basic integration](./custom-ui-basic-integration) document.
+To understand the fundamentals of Ory APIs and learn how to interact with them in your UI, take a look at the
+[Basic integration](./05_custom-ui-basic-integration.mdx) document.
+
+If you are already familiar with the fundamentals, fork one of the
+[custom user interface quickstarts](../../getting-started/custom-ui.mdx) and start hacking!

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -4,7 +4,7 @@ export const basic: PropTypes = {
   id: "basic",
   title: "Basic examples",
   description:
-    "Guides, tutorials, and configurations for using Ory services. Examples are maintained and tested by the Ory team.",
+    "Guides, tutorials, and configurations for using Ory services. Examples are maintained by the Ory team.",
   examples: [
     {
       title: "Protect a page with login: Next.js/React",
@@ -87,7 +87,7 @@ export const basic: PropTypes = {
       docs: "https://www.ory.sh/securing-flask-application-using-kratos-and-keto/",
     },
     {
-      title: "Protect a page with login: Dotnet",
+      title: "Protect a page with login: .NET Core",
       language: "dotnet",
       author: "ory",
       tested: true,
@@ -95,15 +95,7 @@ export const basic: PropTypes = {
       docs: "https://www.ory.sh/docs/getting-started/integrate-auth/dotnet",
     },
     {
-      title: "Ory Cloud with Supabase Backend",
-      language: "go",
-      author: "ory",
-      tested: false,
-      repo: "https://github.com/ory/examples/tree/master/supabase-ory-cloud",
-      docs: "https://github.com/ory/examples/blob/master/supabase-ory-cloud/README.md",
-    },
-    {
-      title: "Ory Network with ASP.NET Core",
+      title: "Protect a page with login: ASP.NET Core",
       language: "dotnet",
       author: "ory",
       tested: false,
@@ -118,7 +110,7 @@ export const customui: PropTypes = {
   id: "customui",
   title: "Custom UI examples",
   description:
-    "Guides, tutorials, and configurations for building a custom UI for Ory services. Examples are maintained and tested by the Ory team.",
+    "Guides, tutorials, and configurations for building a custom UI for Ory services. Examples are maintained by the Ory team.",
   examples: [
     {
       title: "Customize self-service UI: Node.js",

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -1,10 +1,10 @@
 import { PropTypes } from "../../components/Examples/example-list"
 
-export const official: PropTypes = {
-  id: "official",
-  title: "Official examples",
+export const basic: PropTypes = {
+  id: "basic",
+  title: "Basic examples",
   description:
-    "Guides, tutorials, and configurations for using Ory services. Examples maintained and tested by the Ory team.",
+    "Guides, tutorials, and configurations for using Ory services. Examples are maintained and tested by the Ory team.",
   examples: [
     {
       title: "Protect a page with login: Next.js/React",
@@ -95,6 +95,32 @@ export const official: PropTypes = {
       docs: "https://www.ory.sh/docs/getting-started/integrate-auth/dotnet",
     },
     {
+      title: "Ory Cloud with Supabase Backend",
+      language: "go",
+      author: "ory",
+      tested: false,
+      repo: "https://github.com/ory/examples/tree/master/supabase-ory-cloud",
+      docs: "https://github.com/ory/examples/blob/master/supabase-ory-cloud/README.md",
+    },
+    {
+      title: "Ory Network with ASP.NET Core",
+      language: "dotnet",
+      author: "ory",
+      tested: false,
+      repo: "https://github.com/ory/examples/tree/master/dotnet-ory-network",
+      docs: "https://github.com/ory/examples/blob/master/dotnet-ory-network/README.md",
+      description: "Advanced example",
+    },
+  ],
+}
+
+export const customui: PropTypes = {
+  id: "customui",
+  title: "Custom UI examples",
+  description:
+    "Guides, tutorials, and configurations for building a custom UI for Ory services. Examples are maintained and tested by the Ory team.",
+  examples: [
+    {
       title: "Customize self-service UI: Node.js",
       language: "nodejs",
       author: "ory",
@@ -117,23 +143,6 @@ export const official: PropTypes = {
       tested: false,
       repo: "https://github.com/ory/kratos-selfservice-ui-react-native",
       docs: "https://www.ory.sh/login-react-native-authentication-example-api/",
-    },
-    {
-      title: "Ory Cloud with Supabase Backend",
-      language: "go",
-      author: "ory",
-      tested: false,
-      repo: "https://github.com/ory/examples/tree/master/supabase-ory-cloud",
-      docs: "https://github.com/ory/examples/blob/master/supabase-ory-cloud/README.md",
-    },
-    {
-      title: "Ory Network with ASP.NET Core",
-      language: "dotnet",
-      author: "ory",
-      tested: false,
-      repo: "https://github.com/ory/examples/tree/master/dotnet-ory-network",
-      docs: "https://github.com/ory/examples/blob/master/dotnet-ory-network/README.md",
-      description: "Advanced example",
     },
   ],
 }

--- a/src/pages/_assets/examples-content.tsx
+++ b/src/pages/_assets/examples-content.tsx
@@ -141,7 +141,7 @@ export const customui: PropTypes = {
 
 export const community: PropTypes = {
   id: "community",
-  title: "Community Examples",
+  title: "Community examples",
   description:
     "Guides, tutorials, and configurations for using Ory services contributed by the Ory community.",
   examples: [

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -29,6 +29,7 @@ module.exports = {
           ],
         },
         "guides/permissions/overview",
+        "getting-started/custom-ui",
       ],
     },
     {


### PR DESCRIPTION
- creates separate page and sidebar item for custom ui examples/quickstarts
- adds a mention of the custom ui examples on next steps of custom UI overview.

tangentially related minor fixes:
- removes outdated supabase example from overview
- minor style improvements

We can probably link to the custom ui examples in other places as well, but this felt like the most natural start - I did not want to go through all docs and see where it could fit.
