### PR TITLE
fix: self-hosted deploy guides latestversion

### DIFF
--- a/docs/hydra/self-hosted/configure-deploy.mdx
+++ b/docs/hydra/self-hosted/configure-deploy.mdx
@@ -131,15 +131,11 @@ Let's dive into the various settings:
 - `-e URLS_LOGIN=http://localhost:9020/login` this sets the URL of the login provider **(required)**. We will set up the service
   that handles requests at that URL in the next sections.
 
-:::note
-
 In this example we didn't define a value for the optional setting `URLS_ERROR`. This URL can be used to provide an endpoint which
 will receive error messages from Ory Hydra that should be displayed to the end user. The URL receives `error` and
 `error_description` parameters. If this value isn't set, Hydra uses the fallback endpoint `/oauth2/fallbacks/error` and displays a
 default error message. In order to obtain a uniform UI, you might want to include such an endpoint in your login or consent
 provider.
-
-:::
 
 :::note
 

--- a/docs/hydra/self-hosted/deploy-hydra-example.mdx
+++ b/docs/hydra/self-hosted/deploy-hydra-example.mdx
@@ -185,18 +185,11 @@ Congratulations, you have installed and configured the PostgreSQL database. Next
 
 You should see something like this once the service has been started:
 
-```bash
-WARN[2022-04-15T15:24:29Z] JSON Web Key Set "hydra.openid.id-token" does not exist yet, generating new key pair...  audience=application service_name=Ory Hydra service_version=v1.11.7
-WARN[2022-04-15T15:24:34Z] JSON Web Key Set "hydra.jwt.access-token" does not exist yet, generating new key pair...  audience=application service_name=Ory Hydra service_version=v1.11.7
-Thank you for using Ory Hydra v1.11.7!
-
-Take security seriously and subscribe to the Ory Security Newsletter. Stay on top of new patches and security insights.
-
->> Subscribe now: http://eepurl.com/di390P <<
-INFO[2022-04-15T15:24:37Z] Software quality assurance features are enabled. Learn more at: https://www.ory.sh/docs/ecosystem/sqa  audience=application service_name=Ory Hydra service_version=v1.11.7
-WARN[2022-04-15T15:24:37Z] JSON Web Key Set "hydra.https-tls" does not exist yet, generating new key pair...  audience=application service_name=Ory Hydra service_version=v1.11.7
-INFO[2022-04-15T15:24:41Z] Setting up http server on :4444               audience=application service_name=Ory Hydra service_version=v1.11.7
-INFO[2022-04-15T15:24:41Z] Setting up http server on :4445               audience=application service_name=Ory Hydra service_version=v1.11.7
+```mdx-code-block
+   <CodeBlock className="language-shell">{`WARN[2022-04-15T15:24:29Z] JSON Web Key Set "hydra.openid.id-token" does not exist yet, generating new key pair...  audience=application service_name=Ory Hydra service_version=${useLatestRelease("hydra")}
+WARN[2022-04-15T15:24:34Z] JSON Web Key Set "hydra.jwt.access-token" does not exist yet, generating new key pair...  audience=application service_name=Ory Hydra service_version=${useLatestRelease("hydra")}
+Thank you for using Ory Hydra ${useLatestRelease("hydra")}!
+`}</CodeBlock>
 ```
 
 ## Run Ory Hydra using systemd
@@ -206,6 +199,8 @@ INFO[2022-04-15T15:24:41Z] Setting up http server on :4445               audienc
    ```bash
    chown -R hydra /opt/hydra/
    ```
+
+````
 
 2. Create a `/etc/systemd/system/hydra.service` file
 
@@ -486,3 +481,4 @@ server {
 - Fork the [Ory Hydra Node.js UI Reference](https://github.com/ory/hydra-login-consent-node) or
   [build a custom UI in the language of your choice](../sdk/01_overview.md).
 - [Add Identity and Account Management](../../kratos/ory-kratos-intro)
+````

--- a/docs/kratos/guides/deploy-kratos-example.mdx
+++ b/docs/kratos/guides/deploy-kratos-example.mdx
@@ -209,11 +209,12 @@ Kratos.
 
 You should see something like this once the service has been started:
 
-```bash
-INFO[2022-05-10T20:51:56Z] TLS has not been configured for public, skipping  audience=application service_name=Ory Kratos service_version=v0.9.0-alpha.3
-INFO[2022-05-10T20:51:56Z] Starting the public httpd on: 0.0.0.0:4433    audience=application service_name=Ory Kratos service_version=v0.9.0-alpha.3
-INFO[2022-05-10T20:51:56Z] TLS has not been configured for admin, skipping  audience=application service_name=Ory Kratos service_version=v0.9.0-alpha.3
-INFO[2022-05-10T20:51:56Z] Starting the admin httpd on: 0.0.0.0:4434     audience=application service_name=Ory Kratos service_version=v0.9.0-alpha.3
+```mdx-code-block
+   <CodeBlock className="language-shell">{`INFO[2022-05-10T20:51:56Z] TLS has not been configured for public, skipping  audience=application service_name=Ory Kratos service_version=${useLatestRelease("kratos")}
+INFO[2022-05-10T20:51:56Z] Starting the public httpd on: 0.0.0.0:4433    audience=application service_name=Ory Kratos service_version=${useLatestRelease("kratos")}
+INFO[2022-05-10T20:51:56Z] TLS has not been configured for admin, skipping  audience=application service_name=Ory Kratos service_version=${useLatestRelease("kratos")}
+INFO[2022-05-10T20:51:56Z] Starting the admin httpd on: 0.0.0.0:4434     audience=application service_name=Ory Kratos service_version=${useLatestRelease("kratos")}
+`}</CodeBlock>
 ```
 
 ## Run Ory Kratos using systemd


### PR DESCRIPTION
changes the code snippets to show latest version. 

(to prevent [gpt bot](https://app.kapa.ai/conversations/94164c1a-d0f5-4139-a0a6-ba0e10d4853e?projectId=clheldcpm00033b6pb98cagzl) answers with outdated versions)