### PR TITLE
fix: missing eof

### DIFF
--- a/docs/oathkeeper/configure-deploy.mdx
+++ b/docs/oathkeeper/configure-deploy.mdx
@@ -396,6 +396,7 @@ scrape_configs:
     static_configs:
       # The target needs to match what you've configured above
       - targets: ['localhost:9000']
+EOF
 ```
 
 Run the following commands to start the Prometheus server and access it on [http://localhost:9090](http://localhost:9090):


### PR DESCRIPTION
Simple fix for missing EOF, causing shell block when copy.