### PR TITLE
chore: fix typo

### DIFF
--- a/docs/keto/concepts/15_subjects.mdx
+++ b/docs/keto/concepts/15_subjects.mdx
@@ -13,7 +13,7 @@ application, for example users, or to sets of subjects.
 
 A subject ID can be any string. The application must map its resources to a constant, unique identifiers. We recommend using UUIDs
 as they provide a high entropy and therefore are unique identifiers. However, you can also use URLs or opaque tokens as
-identifiers. Objects are considered equal when their string representation is equal.
+identifiers. Subjects are considered equal when their string representation is equal.
 
 ## Subject sets
 


### PR DESCRIPTION
Fixed typo in documentation for subjects (Object vs Subject)
