### PR TITLE
fix: link to github discussions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = {
               label: "Ory Community Slack",
             },
             {
-              to: "https://www.ory.sh/support",
+              to: "https://github.com/orgs/ory/discussions",
               label: "GitHub Discussions",
             },
             {


### PR DESCRIPTION
Link to the correct page