### PR TITLE
fix: update basePath config in index.js

### DIFF
--- a/code-examples/protect-page-login/expressjs/routes/index.js
+++ b/code-examples/protect-page-login/expressjs/routes/index.js
@@ -9,7 +9,7 @@ var sdk = require("@ory/client")
 var ory = new sdk.FrontendApi(
   new sdk.Configuration({
     basePath:
-      process.env.ORY_SDK_URL || "https://playground.projects.oryapis.com",
+      "http://localhost:4000/.ory",
   }),
 )
 // highlight-end


### PR DESCRIPTION
AFAI understood, the basePath in the SDK configuration should point to the proxy and not to <slug>.projects.oryapis.com. When pointing to oryapis.com or the ORY_SDK_URL, the login works, but calling `createBrowserLogoutFlow` returns a logout url, which leads to an error (Unable to log out because the logout token in the URL query does not match the session cookie). 
TBH I'm not sure if the basePath should point to `http://localhost:4000/.ory` or `http://localhost:4000`

