### PR TITLE
revert: cache change

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,17 +4,6 @@
   },
   "cleanUrls": true,
   "trailingSlash": false,
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=22118400"
-        }
-      ]
-    }
-  ],
   "redirects": [
     {
       "source": "/",


### PR DESCRIPTION
@LBBO this new cache logic lead to quite serious problems on the documentation. The reason is that it simply is a catch-all cache which sets an insanely high lifetime. This leads to (in hindsight) very obvious problems:

- All pages, all HTML, all images, all assets - everything is cached for basically forever
- If all HTML is cached forever, it may very well refer to old assets which no longer exist both on th server and the client. This breaks the site (see for example #1489)
- Because we use cloudflare with edge caching, and it is also explicitly enabled by the `public` directive. This not only stores outdated assets (such as HTML pages) on the client - it stores them in Cloudflare. This significantly makes the problem of broken pages worse due to a shared state.

Caching is not an easy problem. Never just cache everything forever, and always roll out caches iteratively and monitor the changes correctly.

Write caching rules that make sense. You want to cache javascript assets that have a hash ID? Sure, do that, it's very unlikely that these files will ever change. Caching `index.html`? Really bad idea, that file will change frequently and the cache MUST NOT be used then.

I should have paid more attention during review but thankfully the issue was noticed relatively quickly - we did have a couple of broken pages though, and page health deteriorated from 91% to 50%.