### PR TITLE
feat: initial account experience docs

### DIFF
--- a/docs/account-experience/index.mdx
+++ b/docs/account-experience/index.mdx
@@ -10,13 +10,14 @@ Account Experience. You can find various customizations and settings in the Ory 
 
 ## Theming
 
-The Account Experience can be themed using the Ory Console. You can find the theme settings under `Account Experience` >
-`Theming`. It is also possible to set a custom logo and favicon.
+The Account Experience can be themed using the Ory Console. Head over to the
+[theming settings](https://console.ory.sh/projects/current/account-experience/theming). It is also possible to set a custom logo
+and favicon.
 
 ## Welcome Screen
 
 The Account Experience comes with a welcome screen that shows information about the current user's session. As this screen is
-rather meant for debugging purposes, it can be disabled in the Ory Console under `Account Experience` > `UI URLs`.
+rather meant for debugging purposes, it can be disabled in the [Ory Console](https://console.ory.sh/projects/current/ui).
 
 ## Translations (i18n) & Message Customization
 

--- a/docs/account-experience/index.mdx
+++ b/docs/account-experience/index.mdx
@@ -1,0 +1,30 @@
+---
+id: index
+title: Account-Experience Overview
+sidebar_label: Account-Experience
+---
+
+The Ory Account Experience is the default user interface for all self-service screens like login, registration, or consent. It can
+be accessed under `https://your-slug.projects.oryapis.com/ui`. New Ory Network projects are automatically configured to use the
+Account Experience. You can find various customizations and settings in the Ory Console under `Account Experience`.
+
+## Theming
+
+The Account Experience can be themed using the Ory Console. You can find the theme settings under `Account Experience` >
+`Theming`. It is also possible to set a custom logo and favicon.
+
+## Welcome Screen
+
+The Account Experience comes with a welcome screen that shows information about the current user's session. As this screen is
+rather meant for debugging purposes, it can be disabled in the Ory Console under `Account Experience` > `UI URLs`.
+
+## Translations (i18n) & Message Customization
+
+Currently, the account experience is available in English (fallback), Spanish, and German. If you want to add a new language or
+fix some wording, please open a pull request in [ory/elements](https://github.com/ory/elements#internalization-i18n). To determine
+the language to use, the Account Experience uses the `Accept-Language` header. If the language is not available, the fallback
+language (English) is used. Custom translations are not supported at the moment, but please reach out if you need this feature.
+
+## Custom Domains
+
+The Account Experience is also available under custom domains the same way it works on the slug URL.

--- a/docs/kratos/bring-your-own-ui/01_overview.mdx
+++ b/docs/kratos/bring-your-own-ui/01_overview.mdx
@@ -23,10 +23,11 @@ Network.
 
 ## Why should I use Ory Account Experience?
 
-Ory Account Experience is the out-of-the-box UI that comes with every Ory Network project, on all available plans. It allows you
-to start using Ory without the need to understand the APIs in detail. With Ory Account Experience, your UI adjusts dynamically to
-reflect the changes in your project configuration, such as adding new social sign-in connectors. You can also make the look of the
-Account Experience UI match your brand using the customization tools available in the Ory Console.
+[Ory Account Experience](../../account-experience/index.mdx) is the out-of-the-box UI that comes with every Ory Network project,
+on all available plans. It allows you to start using Ory without the need to understand the APIs in detail. With Ory Account
+Experience, your UI adjusts dynamically to reflect the changes in your project configuration, such as adding new social sign-in
+connectors. You can also make the look of the Account Experience UI match your brand using the customization tools available in
+the Ory Console.
 
 To see the Ory Account Experience in action and customize the views, go to the **Overview** and **Theming** views of the **Account
 Experience** section in the Ory Console.

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -282,6 +282,7 @@ module.exports = {
         },
       ],
     },
+    "account-experience/index",
     {
       type: "category",
       label: "Ory CLI",


### PR DESCRIPTION
All sections on the overview page could go into their own page with more content, but having the basics all on one page for now is already better than nothing.