### PR TITLE
fix: add dark mode for diagrams (#1213)

### DIFF
--- a/src/theme/Mermaid.js
+++ b/src/theme/Mermaid.js
@@ -13,6 +13,7 @@
 // `}/>
 
 import React, { useEffect, useState } from "react"
+import { useColorMode } from "@docusaurus/theme-common"
 import mermaid from "mermaid"
 import styles from "./mermaid.module.css"
 import cn from "classnames"
@@ -43,11 +44,19 @@ const Mermaid = ({ chart }) => {
   const [svg, setSvg] = useState(undefined)
   const [id] = useState(`mermaid-${Math.random().toString(36).substr(2, -1)}`)
   const toggle = () => setZoomed(!zoomed)
+  const { colorMode } = useColorMode()
 
   useEffect(() => {
-    mermaid.render(id, chart, (svg) => {
-      setSvg(svg)
-    })
+    // https://mermaid.js.org/config/theming.html#diagram-specific-themes
+    mermaid.render(
+      id,
+      `%%{init: {'theme':'${
+        colorMode === "light" ? "neutral" : "dark"
+      }'}}%%\n${chart}`,
+      (svg) => {
+        setSvg(svg)
+      },
+    )
   }, [])
 
   return (


### PR DESCRIPTION
This pull request adds the dark mode theme for mermaid diagrams that match the selected theme.

## Related Issue or Design Document

#1213 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

This fix only applies after a page refresh if the page has a diagram. This is due to the mermaid package refreshing it empty (and I don't know why).

We can open a new issue to fix this bug later, while still keeping diagrams more visible than today.