### PR TITLE
fix: correct default refresh token TTL

### DIFF
--- a/docs/oauth2-oidc/refresh-token-grant.mdx
+++ b/docs/oauth2-oidc/refresh-token-grant.mdx
@@ -127,7 +127,8 @@ can consider the following storage layers:
 
 ## Change refresh token lifespan
 
-You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 30 days.
+You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 30 
+days.
 
 :::note
 

--- a/docs/oauth2-oidc/refresh-token-grant.mdx
+++ b/docs/oauth2-oidc/refresh-token-grant.mdx
@@ -127,7 +127,7 @@ can consider the following storage layers:
 
 ## Change refresh token lifespan
 
-You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 30 
+You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 30
 days.
 
 :::note

--- a/docs/oauth2-oidc/refresh-token-grant.mdx
+++ b/docs/oauth2-oidc/refresh-token-grant.mdx
@@ -127,8 +127,7 @@ can consider the following storage layers:
 
 ## Change refresh token lifespan
 
-You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 1
-hour.
+You can adjust the Refresh Token lifespan (TTL) using the `/ttl/refresh_token` configuration key. By default, the TTL is set to 30 days.
 
 :::note
 


### PR DESCRIPTION
## Related Issue or Design Document

[This page](https://www.ory.sh/docs/hydra/guides/client-token-expiration#refresh-token) mentions that the default refresh token in Ory lasts for 30 days, and that's what we found out when we tried. So unless the two pages are talking about different refresh tokens, 1 hour is incorrect and this PR is to fix that.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
