### PR TITLE
chore: add oathkeeper authn oauth2 introspection max_cost configuration

### DIFF
--- a/docs/oathkeeper/pipeline/authn.md
+++ b/docs/oathkeeper/pipeline/authn.md
@@ -478,7 +478,7 @@ This authenticator will use the username from the HTTP Basic Authorization heade
     false.
   - `ttl` (string) - Can override the default behavior of using the token exp time, and specify a set time to live for the token
     in the cache. If the token exp time is lower than the set value the token exp time will be used instead.
-  - `max_tokens` (int) - Max number of tokens to cache.
+  - `max_tokens` (int) - Max number of tokens to cache. Defaults to 1000.
 - `required_scope` ([]string, optional) - Sets what scope is required by the URL and when making performing OAuth 2.0 Client
   Credentials request, the scope will be included in the request:
 
@@ -606,6 +606,7 @@ Token Introspection to check if the token is valid and if the token was granted 
     false.
   - `ttl` (string) - Can override the default behavior of using the token exp time, and specify a set time to live for the token
     in the cache.
+  - `max_cost` (int) - Max cost to cache. Defaults to 100000000.
 
 Please note that caching won't be used if the scope strategy is `none` and `required_scope` isn't empty. In that case, the
 configured introspection URL will always be called and is expected to check if the scope is valid or not.


### PR DESCRIPTION
Cache configuration documentation is missing the `max_cost` option.
Link: https://www.ory.sh/docs/oathkeeper/pipeline/authn#oauth2_introspection-configuration

## Related Issue or Design Document

Related Oathkeeper PR: https://github.com/ory/oathkeeper/pull/1176
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
