### PR TITLE
Update cache.mdx - filename typo

### DIFF
--- a/docs/concepts/cache.mdx
+++ b/docs/concepts/cache.mdx
@@ -130,7 +130,7 @@ To turn on Edge Sessions, go to **Authentication** → **Sessions** in the
 
 2. Add the configuration for Edge Sessions:
 
-    ```yaml title="config.yml"
+    ```yaml title="identity-config.yml"
     feature_flags:
       cacheable_sessions: true
       cacheable_sessions_max_age: "1m"


### PR DESCRIPTION
The two surrounding snippets say `identity-config.yml`, but the file box itself is titled `config.yml`.