### PR TITLE
fix: configuration reference

### DIFF
--- a/docs/hydra/reference/configuration.mdx
+++ b/docs/hydra/reference/configuration.mdx
@@ -6,5 +6,5 @@ title: Configuration
 ```mdx-code-block
 import ConfigMarkdown from '@site/src/components/ConfigMarkdown';
 
-<ConfigMarkdown src="https://raw.githubusercontent.com/ory/hydra/master/spec/config.json" binary="hydra" />
+<ConfigMarkdown src="https://raw.githubusercontent.com/ory/hydra/master/.schema/config.schema.json" binary="hydra" />
 ```

--- a/docs/keto/reference/configuration.mdx
+++ b/docs/keto/reference/configuration.mdx
@@ -6,5 +6,5 @@ title: Configuration
 ```mdx-code-block
 import ConfigMarkdown from '@site/src/components/ConfigMarkdown';
 
-<ConfigMarkdown src="https://raw.githubusercontent.com/ory/keto/master/embedx/config.schema.json" binary="keto" />
+<ConfigMarkdown src="https://raw.githubusercontent.com/ory/keto/master/.schema/config.schema.json" binary="keto" />
 ```

--- a/docs/kratos/reference/configuration.mdx
+++ b/docs/kratos/reference/configuration.mdx
@@ -6,5 +6,5 @@ title: Configuration
 ```mdx-code-block
 import ConfigMarkdown from '@site/src/components/ConfigMarkdown';
 
-<ConfigMarkdown src="https://raw.githubusercontent.com/ory/kratos/master/embedx/config.schema.json" binary="kratos" />
+<ConfigMarkdown src="https://raw.githubusercontent.com/ory/kratos/master/.schemastore/config.schema.json" binary="kratos" />
 ```

--- a/docs/oathkeeper/reference/configuration.mdx
+++ b/docs/oathkeeper/reference/configuration.mdx
@@ -6,5 +6,5 @@ title: Configuration
 ```mdx-code-block
 import ConfigMarkdown from '@site/src/components/ConfigMarkdown';
 
-<ConfigMarkdown src="https://raw.githubusercontent.com/ory/oathkeeper/master/spec/config.schema.json" binary="oathkeeper" />
+<ConfigMarkdown src="https://raw.githubusercontent.com/ory/oathkeeper/master/.schema/config.schema.json" binary="oathkeeper" />
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "docusaurus": "docusaurus",
     "gen:api": "mkdir -p .static && cp ../spec/api.json src/static/api.json",
     "gen:config": "node src/scripts/config.js config.js",
-    "start": "docusaurus start",
+    "start": "docusaurus start --no-minify",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "serve": "docusaurus serve",

--- a/src/components/ConfigMarkdown/index.tsx
+++ b/src/components/ConfigMarkdown/index.tsx
@@ -11,8 +11,8 @@ import CodeBlock from "@theme/CodeBlock"
 const parser = new RefParser()
 
 const refs = {
-  "ory://tracing-config": `https://raw.githubusercontent.com/ory/x/v0.0.543/otelx/config.schema.json`,
-  "ory://logging-config": `https://raw.githubusercontent.com/ory/x/v0.0.543/logrusx/config.schema.json`,
+  "ory://tracing-config": `https://raw.githubusercontent.com/ory/x/master/otelx/config.schema.json`,
+  "ory://logging-config": `https://raw.githubusercontent.com/ory/x/master/logrusx/config.schema.json`,
 }
 
 const enhance =


### PR DESCRIPTION
After this change, we use the complete rendered config from the latest release. The sub-schemas for tracing and logging are generated in the individual repos.

Ref https://github.com/ory/oathkeeper/pull/1202 needed for oathkeeper to work.