### PR TITLE
fix: handle auth0 export job state of "processing"

### DIFF
--- a/code-examples/migrate-to-ory/0-get-auth0-user-data.sh
+++ b/code-examples/migrate-to-ory/0-get-auth0-user-data.sh
@@ -36,7 +36,7 @@ poll_job_status() {
     state=$(echo $jobstatus | jq -r ".status")
     echo "jobstate: ${state}"
 
-    if [[ $state == "pending" ]]; then
+    if [[ $state == "pending" ]] || [[ $state == "processing" ]]; then
         echo "${jobstatus}" | jq ".time_left_seconds" | read timeleft
         if [ -z $timeleft]; then
             sleep 1


### PR DESCRIPTION
For auth0 export jobs against connections with a large number of users, there's an additional job state, `processing`, which does not seem to be accounted for. 

This fix treats the handling of `processing` like `pending`, waiting for the job to finish before moving on to the next step.
