### PR TITLE
fix: correct config example for creating new array item by env var

### DIFF
--- a/docs/ecosystem/configuring.md
+++ b/docs/ecosystem/configuring.md
@@ -122,7 +122,7 @@ As you can see, subkeys are separated with an underscore `_`. If a subkey is an 
 the array index (`0`, `1`). It is also possible to define a new array by using an array index that isn't yet set:
 
 ```shell
-export SOME_NESTED_KEY_AND_ARRAY_2_BAR=baz
+export SOME_NESTED_KEY_AND_ARRAY_2_ID=baz
 ```
 
 The above would result in:
@@ -133,7 +133,8 @@ some:
     with_a_value: foo
     and_array:
       - id: foo
-      - bar: bar
+      - id: bar
+      - id: baz
 ```
 
 It's also possible to use JSON strings to denote complex configuration keys:


### PR DESCRIPTION
The documentation states:

> It is also possible to define a new array by using an array index that isn't yet set:

But the result that follows the example does not show a new, third array item, and is also not consistent with the example before where the array items contained "id"s.

## Related Issue or Design Document

-

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

-
