### PR TITLE
fix(docs): fix dotnet quickstart code blocks

### DIFF
--- a/docs/getting-started/integrate-auth/40_dotnet.mdx
+++ b/docs/getting-started/integrate-auth/40_dotnet.mdx
@@ -179,7 +179,7 @@ app.Run();
 
 2. Add this code to the `Pages/Index.cshtml` file to present the data to the user:
 
-   ```cshtml title="Pages/Index.cshtml" showLineNumbers
+   ```csharp title="Pages/Index.cshtml" showLineNumbers
    @page
    @{
    // add-lines-start

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -61,7 +61,6 @@ svg[class*="iconExternalLink"] {
   background-color: rgba(255, 0, 0, 0.2);
   margin: 0 -12px;
   padding: 0 12px;
-  display: block;
   text-decoration: line-through;
 }
 
@@ -69,7 +68,6 @@ svg[class*="iconExternalLink"] {
   background-color: rgba(0, 255, 0, 0.2);
   margin: 0 -12px;
   padding: 0 12px;
-  display: block;
 }
 
 @media (max-width: 996px) {


### PR DESCRIPTION
Small fix for the dotnet quick start code blocks looking off.

- Removed `display: block` for add and delete lines css.
- Changed code blocks type from 'cshtml' to 'csharp' as cshtml is not supported.

Reference: Issue #2230 

