### PR TITLE
fix 16_nextjs_app_router.mdx to be clearer

### DIFF
--- a/docs/getting-started/integrate-auth/16_nextjs_app_router.mdx
+++ b/docs/getting-started/integrate-auth/16_nextjs_app_router.mdx
@@ -10,6 +10,8 @@ import CodeFromRemote from "@theme/CodeFromRemote"
 
 This quickstart will guide you through the process of setting up Ory Elements with the App Router in a Next.js application.
 
+Disclaimer: When setting up this Next.js project, the guide assumes you're using the alias configuration and not using a src/ directory. If you've chosen to place your code inside a src/ folder, then any time the guide references the "root" directory, place those files inside src/ instead.
+
 :::info
 
 The code used in the following quickstart is available in the


### PR DESCRIPTION
As a user following this quickstart, it was unclear that the guide uses an alias. 
The config and middleware files were to be placed in the root, but if a user has chosen to use a src/ directory, then the user will run into problems. 

This change is to prevent such problems from arising.