### PR TITLE
chore: remove deprecated/experimental audit logs

### DIFF
--- a/docs/self-hosted/operations/20_logging.md
+++ b/docs/self-hosted/operations/20_logging.md
@@ -73,16 +73,6 @@ If `LOG_LEVEL=trace`, traces will be included for log calls and errors:
 
 Ory provides as much context as possible for each log operation.
 
-### Audience
-
-The `audience` field distinguishes between `application` logs intended for operators and developers, and `audit` logs that
-document allowed and denied authorizations, failed and succeeded log in attempts, and so on:
-
-```sh
-time=2020-05-20T11:57:09+02:00 level=info msg=An example log message. audience=application service_name=foo service_version=bar
-time=2020-05-20T11:57:29+02:00 level=info msg=Login successful. audience=audit service_name=foo service_version=bar
-```
-
 ### HTTP request context
 
 We include vital HTTP request info whenever possible:


### PR DESCRIPTION
Code PR: https://github.com/ory-corp/cloud/pull/10206

> [...] only used in a couple of places. initially this was my idea to use the logging for this but we‘re not really able to comb through all of the logs on prod at scale so it makes much more sense to use the eventing system. you can consider the audit log stuff obsolete/deprecated/unused