### PR TITLE
docs: document enum identity schema dropdowns

### DIFF
--- a/docs/kratos/manage-identities/15_customize-identity-schema.mdx
+++ b/docs/kratos/manage-identities/15_customize-identity-schema.mdx
@@ -205,6 +205,47 @@ their GitHub handle, which is clear thanks to the field description defined in t
 </Tabs>
 ````
 
+## Restrict values with `enum`
+
+Use the JSON Schema `enum` keyword to restrict a trait to a fixed set of
+allowed values. When you declare an `enum` on a string property, the Ory
+Account Experience renders the field as a dropdown (a native `<select>`) and
+only accepts values from the list at registration, settings, and admin updates.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": "string",
+          "title": "Country",
+          "enum": ["US", "UK", "DE", "AT"]
+        }
+      },
+      "required": ["country"]
+    }
+  }
+}
+```
+
+Kratos surfaces the allowed values on the UI node by attaching an `options`
+array to the input attributes. Custom UIs that already know how to render a
+UI node can read `attributes.options` and display a `<select>`; UIs that do
+not look at `options` fall back to a plain text input, so the change is
+backward compatible with older custom UIs.
+
+:::note
+
+Only top-level string properties under `traits` are supported today. The
+rendered option value is used as both the submitted value and the visible
+label.
+
+:::
+
 ## Identity schema extensions
 
 Because the system doesn't know which fields have system-relevant meaning, you have to specify that in the schema. For example:

--- a/docs/kratos/manage-identities/15_customize-identity-schema.mdx
+++ b/docs/kratos/manage-identities/15_customize-identity-schema.mdx
@@ -232,7 +232,7 @@ only accepts values from the list at registration, settings, and admin updates.
 }
 ```
 
-Kratos surfaces the allowed values on the UI node by attaching an `options`
+Ory Kratos surfaces the allowed values on the UI node by attaching an `options`
 array to the input attributes. Custom UIs that already know how to render a
 UI node can read `attributes.options` and display a `<select>`; UIs that do
 not look at `options` fall back to a plain text input, so the change is
@@ -240,7 +240,7 @@ backward compatible with older custom UIs.
 
 :::note
 
-Only top-level string properties under `traits` are supported today. The
+Only top-level string properties under `traits` are supported. The
 rendered option value is used as both the submitted value and the visible
 label.
 

--- a/docs/kratos/manage-identities/15_customize-identity-schema.mdx
+++ b/docs/kratos/manage-identities/15_customize-identity-schema.mdx
@@ -207,10 +207,9 @@ their GitHub handle, which is clear thanks to the field description defined in t
 
 ## Restrict values with `enum`
 
-Use the JSON Schema `enum` keyword to restrict a trait to a fixed set of
-allowed values. When you declare an `enum` on a string property, the Ory
-Account Experience renders the field as a dropdown (a native `<select>`) and
-only accepts values from the list at registration, settings, and admin updates.
+Use the JSON Schema `enum` keyword to restrict a trait to a fixed set of allowed values. When you declare an `enum` on a string
+property, the Ory Account Experience renders the field as a dropdown (a native `<select>`) and only accepts values from the list
+at registration, settings, and admin updates.
 
 ```json
 {
@@ -232,17 +231,14 @@ only accepts values from the list at registration, settings, and admin updates.
 }
 ```
 
-Ory Kratos surfaces the allowed values on the UI node by attaching an `options`
-array to the input attributes. Custom UIs that already know how to render a
-UI node can read `attributes.options` and display a `<select>`; UIs that do
-not look at `options` fall back to a plain text input, so the change is
-backward compatible with older custom UIs.
+Ory Kratos surfaces the allowed values on the UI node by attaching an `options` array to the input attributes. Custom UIs that
+already know how to render a UI node can read `attributes.options` and display a `<select>`; UIs that do not look at `options`
+fall back to a plain text input, so the change is backward compatible with older custom UIs.
 
 :::note
 
-Only top-level string properties under `traits` are supported. The
-rendered option value is used as both the submitted value and the visible
-label.
+Only top-level string properties under `traits` are supported. The rendered option value is used as both the submitted value and
+the visible label.
 
 :::
 


### PR DESCRIPTION
## Summary

- Describe the new behavior where declaring a string `enum` on an identity schema trait renders the field as a native `<select>` in the Ory Account Experience.
- Document the `options` array attached to `InputAttributes` on the UI node so teams running a custom UI know how to render the dropdown.

Related: https://github.com/ory-corp/cloud/issues/10921

## Test plan

- [ ] Preview the "Customize identity schemas" page and verify the new "Restrict values with `enum`" section renders correctly and sits in the right place in the outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guide on using enum constraints to restrict identity schema string property values
  * Shows runtime behavior: enum-backed fields render as dropdowns in registration, settings, and admin flows
  * Documents that allowed values are exposed to UIs via input attributes for building selects
  * Notes fallback to plain-text input for UIs that ignore provided options
  * Clarifies limitation to top-level string traits and that option value doubles as label
<!-- end of auto-generated comment: release notes by coderabbit.ai -->