### PR TITLE
docs: point compliance page to Ory Trust Center

### DIFF
--- a/docs/security-compliance/compliance-and-certifications.md
+++ b/docs/security-compliance/compliance-and-certifications.md
@@ -10,12 +10,10 @@ programs and adopted the best industry practices and technologies to keep our cu
 
 ## ISO 27001
 
-Ory holds a certificate for [ISO 27001:2013](https://www.iso.org/standard/27001), which you can can
-[download for inspection](https://www.ory.com/resources/iso27001/OryCorp-ISO27001-Certificate-of-Registration.pdf). You can also
-verify the ISO 27001:2013 certification directly with [our auditor](https://barrcertifications.com/certificate-directory/). The
-ISO 27001 certification verifies that Ory has an information security management system (ISMS) in place to assure the
-confidentiality and integrity of your data. Our internal security team is dedicated to ensuring that Ory maintains the highest
-standards of data protection.
+Ory holds a certificate for [ISO 27001:2022](https://www.iso.org/standard/27001). The ISO 27001 certification verifies that Ory
+has an information security management system (ISMS) in place to assure the confidentiality and integrity of your data. Our
+internal security team is dedicated to ensuring that Ory maintains the highest standards of data protection. To access our ISO
+27001 certificate and all other compliance documentation, visit the [Ory Trust Center](https://trust.ory.com).
 
 ## SOC 2 Type 2
 
@@ -23,8 +21,8 @@ Ory is SOC 2 Type 2 certified. SOC 2 is a framework for assessing the security, 
 confidentiality, and privacy of data in service organizations. It is not a standard but a certification that demonstrates that an
 organization's internal controls and processes meet specific criteria. The Type 2 designation indicates that an independent
 auditor has evaluated and tested these controls over a period of time (typically three months to a year) to ensure they are
-effectively implemented. Current and prospective customers interested in obtaining a copy of Ory’s latest SOC 2 report may request
-access at the [Ory Trust Center](https://trust.ory.com/).
+effectively implemented. Current and prospective customers interested in obtaining a copy of Ory's latest SOC 2 Type 2 report can
+request access at the [Ory Trust Center](https://trust.ory.com).
 
 ## GDPR
 

--- a/src/components/ConsoleLink/console-routes.ts
+++ b/src/components/ConsoleLink/console-routes.ts
@@ -15,10 +15,6 @@ export const routes = {
     twitter: "https://twitter.com/orycorp",
     talkToUs: "https://ory.com/talk-to-us",
   },
-  resources: {
-    iso27001:
-      "https://www.ory.com/resources/iso27001/OryCorp-ISO27001-Certificate-of-Registration.pdf",
-  },
   root: "/",
   "404": "/404",
   _500: "/500",


### PR DESCRIPTION
## Summary
- Bump ISO 27001 reference from the 2013 revision to 2022.
- Remove the direct ISO certificate PDF link and auditor-directory link; point readers to [trust.ory.com](https://trust.ory.com) for the ISO cert, SOC 2 Type 2 report, and all other compliance documentation.
- Drop the now-unused `routes.resources.iso27001` entry in `src/components/ConsoleLink/console-routes.ts`.

The certificate PDF itself is hosted on `ory.com` (not this repo), so removing that asset is a separate follow-up for the website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ISO 27001 certification reference to the 2022 standard
  * Compliance documentation now accessed through Ory Trust Center
  * Refined SOC 2 Type 2 report reference language

<!-- end of auto-generated comment: release notes by coderabbit.ai -->