### PR TITLE
docs: remove closed reference to ory/hydra#3363

### DIFF
--- a/src/components/Shared/self-hosted/deployment.tsx
+++ b/src/components/Shared/self-hosted/deployment.tsx
@@ -336,11 +336,6 @@ export function DeploymentDatabase({ product }: DeploymentDatabaseProps) {
       <p>See also:</p>
       <ul>
         <li>
-          <a href="https://github.com/ory/hydra/issues/3363">
-            https://github.com/ory/hydra/issues/3363
-          </a>
-        </li>
-        <li>
           <a href="https://github.com/ory/kratos/issues/2167">
             https://github.com/ory/kratos/issues/2167
           </a>


### PR DESCRIPTION
Closes #2524

The upstream issue ory/hydra#3363 has been resolved. This PR removes the stale link from the MySQL migration troubleshooting section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up deployment documentation by removing an outdated reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->