### PR TITLE
docs: remove closed reference to ory/kratos#2167

### DIFF
--- a/src/components/Shared/self-hosted/deployment.tsx
+++ b/src/components/Shared/self-hosted/deployment.tsx
@@ -340,11 +340,6 @@ export function DeploymentDatabase({ product }: DeploymentDatabaseProps) {
             https://github.com/ory/hydra/issues/3363
           </a>
         </li>
-        <li>
-          <a href="https://github.com/ory/kratos/issues/2167">
-            https://github.com/ory/kratos/issues/2167
-          </a>
-        </li>
       </ul>
 
       <h3>SQLite</h3>


### PR DESCRIPTION
Closes #2523

The upstream issue ory/kratos#2167 has been resolved. This PR removes the stale link from the MySQL migration troubleshooting section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated reference link from the MySQL/Aurora migrations troubleshooting section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->