### PR TITLE
docs(docs): document Console UI for refresh token rotation config

### DIFF
--- a/docs/hydra/guides/graceful-token-refresh.mdx
+++ b/docs/hydra/guides/graceful-token-refresh.mdx
@@ -33,6 +33,7 @@ you want a longer grace period, as this minimizes the security concerns associat
 :::tip Configure from the Ory Console
 
 On Ory Network, you can set these fields without using the CLI. Open
+
 <ConsoleLink route="project.oauthConfiguration.configure" /> and scroll to "Refresh Token Grant Configuration":
 
 - **Refresh Token Rotation Grace Period**

--- a/docs/hydra/guides/graceful-token-refresh.mdx
+++ b/docs/hydra/guides/graceful-token-refresh.mdx
@@ -30,6 +30,13 @@ you want a longer grace period, as this minimizes the security concerns associat
 
 ## Enable graceful refresh token rotation
 
+:::tip Configure from the Ory Console
+
+On Ory Network, you can configure both the **Refresh Token Rotation Grace Period** and the **Refresh Token Rotation Grace Reuse
+Count** from the Ory Console under **OAuth 2.0 → Configuration → Refresh Token Grant Configuration**, without using the CLI.
+
+:::
+
 To enable graceful refresh token rotation with a specific grace period and a maximum reuse count, for example 60 seconds and 3
 reuses, run the following command:
 

--- a/docs/hydra/guides/graceful-token-refresh.mdx
+++ b/docs/hydra/guides/graceful-token-refresh.mdx
@@ -32,8 +32,11 @@ you want a longer grace period, as this minimizes the security concerns associat
 
 :::tip Configure from the Ory Console
 
-On Ory Network, you can configure both the **Refresh Token Rotation Grace Period** and the **Refresh Token Rotation Grace Reuse
-Count** from the Ory Console under **OAuth 2.0 → Configuration → Refresh Token Grant Configuration**, without using the CLI.
+On Ory Network, you can set these fields without using the CLI. Open
+<ConsoleLink route="project.oauthConfiguration.configure" /> and scroll to "Refresh Token Grant Configuration":
+
+- **Refresh Token Rotation Grace Period**
+- **Refresh Token Rotation Grace Reuse Count**
 
 :::
 


### PR DESCRIPTION
The graceful refresh token rotation guide already documented configuration via the Ory CLI and self-hosted YAML. The Ory Console now exposes the **Refresh Token Rotation Grace Period** and **Grace Reuse Count** in the OAuth 2.0 configuration UI, so this PR adds a tip to point Network users at the Console as the easier path.

Companion to ory-corp/cloud#11802, which surfaced the count field in the Console.