### PR TITLE
chore(docs): update Console URLs after organization nav refactor

### DIFF
--- a/docs/kratos/organizations/organizations.mdx
+++ b/docs/kratos/organizations/organizations.mdx
@@ -65,7 +65,7 @@ Organizations require identifier-first authentication and two-step registration 
 
 To create, update, or delete organizations via the Ory Console, go to
 
-<ConsoleLink route="project.authentication.organizations" />.
+<ConsoleLink route="project.organizations" />.
 
 ```mdx-code-block
 </TabItem>
@@ -132,7 +132,7 @@ After creating an organization, continue by adding one or more SSO OIDC connecti
 <TabItem value="console" label="Ory Console">
 ```
 
-Go to <ConsoleLink route="project.authentication.organizations" /> and continue by configuring the selected organization.
+Go to <ConsoleLink route="project.organizations" /> and continue by configuring the selected organization.
 
 ```mdx-code-block
 </TabItem>
@@ -280,7 +280,7 @@ Before proceeding, ensure you are on a plan that supports SAML SSO. SAML is avai
 <TabItem value="console" label="Ory Console">
 ```
 
-1. Go to <ConsoleLink route="project.authentication.organizations" /> to create an organization.
+1. Go to <ConsoleLink route="project.organizations" /> to create an organization.
 2. Select "Add a new Enterprise SAML SSO connection" and follow the instructions to configure the SAML connection. Fill out the
    following form fields:
 
@@ -508,7 +508,7 @@ servers. Guided walkthroughs are available for Microsoft Entra ID, Google Worksp
 
 ##### Create a link
 
-Go to <ConsoleLink route="project.authentication.organizations" /> and continue by configuring the selected organization.
+Go to <ConsoleLink route="project.organizations" /> and continue by configuring the selected organization.
 
 On the **Edit Organization** page, under the **Onboarding Portal** section, click **Generate link**. If your project has a custom
 domain configured, you must choose between the project slug and the custom domain as the link's base URL. You can then share this

--- a/docs/kratos/organizations/organizations.mdx
+++ b/docs/kratos/organizations/organizations.mdx
@@ -517,7 +517,7 @@ link with the organization administrators.
 ```mdx-code-block
 import BrowserWindow from "@site/src/theme/BrowserWindow"
 
-<BrowserWindow url="https://console.ory.sh/projects/<id>/authentication/organizations/<id>/edit">
+<BrowserWindow url="https://console.ory.sh/projects/<id>/organizations/<id>/onboarding-portal">
     ![Onboarding portal link](./_static/onboarding-portal-link.png)
 </BrowserWindow>
 ```
@@ -552,7 +552,7 @@ For social sign-in, all upstream data is available as `std.extVar('claims')`, in
 non-standard fields.
 [Social Sign-In mapping](https://www.ory.com/docs/kratos/social-signin/data-mapping#write-a-jsonnet-data-mapper)
 
-<BrowserWindow url="https://console.ory.sh/projects/<id>/authentication/organizations/<id>/edit">
+<BrowserWindow url="https://console.ory.sh/projects/<id>/organizations/<id>/onboarding-portal">
   ![Onboarding portal link](./_static/onboarding-portal-link-mappers.png)
 </BrowserWindow>
 

--- a/src/components/ConsoleLink/console-nav-data.ts
+++ b/src/components/ConsoleLink/console-nav-data.ts
@@ -98,10 +98,6 @@ export const authenticationPaths: Path[] = [
     pill: "Preview",
   },
   {
-    title: "Organizations",
-    href: routes.project.authentication.organizations.route,
-  },
-  {
     title: "Sessions",
     href: routes.project.authentication.sessionSettings.route,
   },
@@ -124,6 +120,33 @@ export const authenticationPaths: Path[] = [
   {
     title: "Actions & Webhooks",
     href: routes.project.developers.actions.route,
+  },
+]
+
+export const organizationsPaths: Path[] = [
+  {
+    title: "All organizations",
+    href: routes.project.organizations.route,
+  },
+  {
+    title: "Overview",
+    href: routes.project.organizations.details.route,
+  },
+  {
+    title: "B2B SSO",
+    href: routes.project.organizations.b2bSso.route,
+  },
+  {
+    title: "Onboarding Portal",
+    href: routes.project.organizations.onboardingPortal.route,
+  },
+  {
+    title: "SCIM clients",
+    href: routes.project.organizations.scim.route,
+  },
+  {
+    title: "Identities",
+    href: routes.project.organizations.identities.route,
   },
 ]
 
@@ -234,6 +257,11 @@ export const projectPaths: RootPath[] = [
     title: "Authentication",
     href: routes.project.authentication.route,
     paths: authenticationPaths,
+  },
+  {
+    title: "Organizations",
+    href: routes.project.organizations.route,
+    paths: organizationsPaths,
   },
   {
     title: "Branding",

--- a/src/components/ConsoleLink/console-nav-data.ts
+++ b/src/components/ConsoleLink/console-nav-data.ts
@@ -128,26 +128,6 @@ export const organizationsPaths: Path[] = [
     title: "All organizations",
     href: routes.project.organizations.route,
   },
-  {
-    title: "Overview",
-    href: routes.project.organizations.details.route,
-  },
-  {
-    title: "B2B SSO",
-    href: routes.project.organizations.b2bSso.route,
-  },
-  {
-    title: "Onboarding Portal",
-    href: routes.project.organizations.onboardingPortal.route,
-  },
-  {
-    title: "SCIM clients",
-    href: routes.project.organizations.scim.route,
-  },
-  {
-    title: "Identities",
-    href: routes.project.organizations.identities.route,
-  },
 ]
 
 export const oauthPaths: Path[] = [

--- a/src/components/ConsoleLink/console-routes.ts
+++ b/src/components/ConsoleLink/console-routes.ts
@@ -251,15 +251,35 @@ export const routes = {
         href: (project: string) =>
           `/projects/${project}/authentication/sessions`,
       },
-      organizations: {
-        route: "/projects/[project]/authentication/organizations",
-        href: (project: string) =>
-          `/projects/${project}/authentication/organizations`,
-        edit: {
-          route: "/projects/[project]/authentication/organizations/[id]",
-          href: (project: string, id: string) =>
-            `/projects/${project}/authentication/organizations/${id}`,
-        },
+    },
+    organizations: {
+      route: "/projects/[project]/organizations",
+      href: (project: string) => `/projects/${project}/organizations`,
+      details: {
+        route: "/projects/[project]/organizations/[organization]",
+        href: (project: string, organization: string) =>
+          `/projects/${project}/organizations/${organization}`,
+      },
+      b2bSso: {
+        route: "/projects/[project]/organizations/[organization]/b2b-sso",
+        href: (project: string, organization: string) =>
+          `/projects/${project}/organizations/${organization}/b2b-sso`,
+      },
+      onboardingPortal: {
+        route:
+          "/projects/[project]/organizations/[organization]/onboarding-portal",
+        href: (project: string, organization: string) =>
+          `/projects/${project}/organizations/${organization}/onboarding-portal`,
+      },
+      scim: {
+        route: "/projects/[project]/organizations/[organization]/scim",
+        href: (project: string, organization: string) =>
+          `/projects/${project}/organizations/${organization}/scim`,
+      },
+      identities: {
+        route: "/projects/[project]/organizations/[organization]/identities",
+        href: (project: string, organization: string) =>
+          `/projects/${project}/organizations/${organization}/identities`,
       },
     },
     hostedUI: {


### PR DESCRIPTION
The Ory Console moved organization management out from under Authentication to a top-level entry, and the detail page now uses a left-rail layout with dedicated routes per sub-section. The Onboarding Portal screenshots in the kratos organizations doc point at the old `console.ory.sh/projects/<id>/authentication/organizations/<id>/edit` URL — this PR points them at the new `/organizations/<id>/onboarding-portal` route.

Companion to ory-corp/cloud#11899.

The old URL keeps working via a permanent redirect, but this update keeps the docs in sync with the live UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations is now accessible as a dedicated top-level menu item in the console, providing improved navigation and easier access for administrators.
  * New organization management features: Organization Details, B2B Single Sign-On (SSO) configuration, Onboarding Portal management, SCIM integration, and Identities administration tools are now available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/docs/pull/2555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->