### PR TITLE
fix: wire Talos API and CLI reference sidebars to show all methods

### DIFF
--- a/docs/talos/reference/cli/sidebar.ts
+++ b/docs/talos/reference/cli/sidebar.ts
@@ -1,0 +1,95 @@
+// Hand-maintained navigation tree for the auto-generated Talos CLI reference.
+//
+// The CLI docs (talos-*.md in this directory) are generated from Cobra and ship
+// without a sidebar, so this file mirrors the `talos --help` command hierarchy.
+// When commands are added/removed, update this tree to match the generated pages.
+//
+// Imported by sidebars-oss.ts and sidebars-oel.ts and rendered as the
+// "CLI reference" category (linked to the root `talos` command page).
+const id = (name: string) => `talos/reference/cli/${name}`
+
+const talosCliReference = {
+  type: "category",
+  label: "CLI reference",
+  link: { type: "doc", id: id("talos") },
+  items: [
+    {
+      type: "category",
+      label: "talos jwk",
+      link: { type: "doc", id: id("talos-jwk") },
+      items: [
+        {
+          type: "category",
+          label: "talos jwk generate",
+          link: { type: "doc", id: id("talos-jwk-generate") },
+          items: [
+            id("talos-jwk-generate-ecdsa"),
+            id("talos-jwk-generate-eddsa"),
+            id("talos-jwk-generate-hmac"),
+            id("talos-jwk-generate-rsa"),
+          ],
+        },
+        id("talos-jwk-get"),
+      ],
+    },
+    {
+      type: "category",
+      label: "talos keys",
+      link: { type: "doc", id: id("talos-keys") },
+      items: [
+        id("talos-keys-issue"),
+        id("talos-keys-verify"),
+        id("talos-keys-batch-verify"),
+        id("talos-keys-derive-token"),
+        id("talos-keys-self-revoke"),
+        {
+          type: "category",
+          label: "talos keys issued",
+          link: { type: "doc", id: id("talos-keys-issued") },
+          items: [
+            id("talos-keys-issued-issue"),
+            id("talos-keys-issued-get"),
+            id("talos-keys-issued-list"),
+            id("talos-keys-issued-update"),
+            id("talos-keys-issued-rotate"),
+            id("talos-keys-issued-revoke"),
+          ],
+        },
+        {
+          type: "category",
+          label: "talos keys imported",
+          link: { type: "doc", id: id("talos-keys-imported") },
+          items: [
+            id("talos-keys-imported-import"),
+            id("talos-keys-imported-batch-import"),
+            id("talos-keys-imported-get"),
+            id("talos-keys-imported-list"),
+            id("talos-keys-imported-update"),
+            id("talos-keys-imported-revoke"),
+            id("talos-keys-imported-delete"),
+          ],
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "talos migrate",
+      link: { type: "doc", id: id("talos-migrate") },
+      items: [
+        id("talos-migrate-up"),
+        id("talos-migrate-down"),
+        id("talos-migrate-status"),
+        id("talos-migrate-force"),
+      ],
+    },
+    id("talos-proxy"),
+    {
+      type: "category",
+      label: "talos serve",
+      link: { type: "doc", id: id("talos-serve") },
+      items: [id("talos-serve-public"), id("talos-serve-admin")],
+    },
+  ],
+}
+
+export default talosCliReference

--- a/sidebars-oel.ts
+++ b/sidebars-oel.ts
@@ -2,6 +2,7 @@ import {
   SidebarItem,
   SidebarItemConfig,
 } from "@docusaurus/plugin-content-docs/src/sidebars/types"
+import talosApiSidebar from "./docs/talos/reference/api/sidebar"
 
 type SidebarItemsConfig = SidebarItemConfig[]
 
@@ -576,7 +577,7 @@ const oelSidebar = [
             label: "Reference",
             items: [
               "talos/reference/index",
-              "talos/reference/api/ory-talos-api",
+              ...talosApiSidebar,
               "talos/reference/cli/talos",
               "talos/reference/config",
               "talos/reference/token-format",

--- a/sidebars-oel.ts
+++ b/sidebars-oel.ts
@@ -6,6 +6,20 @@ import talosApiSidebar from "./docs/talos/reference/api/sidebar"
 
 type SidebarItemsConfig = SidebarItemConfig[]
 
+// The generated Talos API sidebar is [overview doc, { category "ApiKeys", items: [...methods] }].
+// Lift the methods into a single "API reference" category linked to the overview page so the
+// navigation reads cleanly instead of exposing the raw OpenAPI tag name.
+const talosApiReference = {
+  type: "category",
+  label: "API reference",
+  link: { type: "doc", id: "talos/reference/api/ory-talos-api" },
+  items: talosApiSidebar.flatMap((item: any) =>
+    typeof item === "object" && "items" in item && Array.isArray(item.items)
+      ? item.items
+      : [],
+  ),
+}
+
 const oelSidebar = [
   {
     type: "category",
@@ -577,7 +591,7 @@ const oelSidebar = [
             label: "Reference",
             items: [
               "talos/reference/index",
-              ...talosApiSidebar,
+              talosApiReference,
               "talos/reference/cli/talos",
               "talos/reference/config",
               "talos/reference/token-format",

--- a/sidebars-oel.ts
+++ b/sidebars-oel.ts
@@ -3,6 +3,7 @@ import {
   SidebarItemConfig,
 } from "@docusaurus/plugin-content-docs/src/sidebars/types"
 import talosApiSidebar from "./docs/talos/reference/api/sidebar"
+import talosCliReference from "./docs/talos/reference/cli/sidebar"
 
 type SidebarItemsConfig = SidebarItemConfig[]
 
@@ -592,7 +593,7 @@ const oelSidebar = [
             items: [
               "talos/reference/index",
               talosApiReference,
-              "talos/reference/cli/talos",
+              talosCliReference,
               "talos/reference/config",
               "talos/reference/token-format",
               "talos/reference/events",

--- a/sidebars-oss.ts
+++ b/sidebars-oss.ts
@@ -1,5 +1,19 @@
 import talosApiSidebar from "./docs/talos/reference/api/sidebar"
 
+// The generated Talos API sidebar is [overview doc, { category "ApiKeys", items: [...methods] }].
+// Lift the methods into a single "API reference" category linked to the overview page so the
+// navigation reads cleanly instead of exposing the raw OpenAPI tag name.
+const talosApiReference = {
+  type: "category",
+  label: "API reference",
+  link: { type: "doc", id: "talos/reference/api/ory-talos-api" },
+  items: talosApiSidebar.flatMap((item: any) =>
+    typeof item === "object" && "items" in item && Array.isArray(item.items)
+      ? item.items
+      : [],
+  ),
+}
+
 const ossSidebar = [
   {
     type: "category",
@@ -584,7 +598,7 @@ const ossSidebar = [
             label: "Reference",
             items: [
               "talos/reference/index",
-              ...talosApiSidebar,
+              talosApiReference,
               "talos/reference/cli/talos",
               "talos/reference/config",
               "talos/reference/token-format",

--- a/sidebars-oss.ts
+++ b/sidebars-oss.ts
@@ -1,4 +1,5 @@
 import talosApiSidebar from "./docs/talos/reference/api/sidebar"
+import talosCliReference from "./docs/talos/reference/cli/sidebar"
 
 // The generated Talos API sidebar is [overview doc, { category "ApiKeys", items: [...methods] }].
 // Lift the methods into a single "API reference" category linked to the overview page so the
@@ -599,7 +600,7 @@ const ossSidebar = [
             items: [
               "talos/reference/index",
               talosApiReference,
-              "talos/reference/cli/talos",
+              talosCliReference,
               "talos/reference/config",
               "talos/reference/token-format",
               "talos/reference/events",

--- a/sidebars-oss.ts
+++ b/sidebars-oss.ts
@@ -1,3 +1,5 @@
+import talosApiSidebar from "./docs/talos/reference/api/sidebar"
+
 const ossSidebar = [
   {
     type: "category",
@@ -582,7 +584,7 @@ const ossSidebar = [
             label: "Reference",
             items: [
               "talos/reference/index",
-              "talos/reference/api/ory-talos-api",
+              ...talosApiSidebar,
               "talos/reference/cli/talos",
               "talos/reference/config",
               "talos/reference/token-format",


### PR DESCRIPTION
## Related Issue or Design Document

Improves the documentation, no issue reference required.

The Talos reference sidebar was broken: the generated API reference sidebar was never wired into the OSS/OEL navigation, so only the overview page showed instead of all 18 API methods, and the CLI reference exposed only a single flat `talos` command entry. This PR wires the generated Talos API reference sidebar into both the OSS and OEL sidebars and groups the methods under a clean "API reference" category linked to the overview page. It also adds a hand-maintained CLI reference sidebar (`docs/talos/reference/cli/sidebar.ts`) that mirrors the `talos --help` command hierarchy and replaces the flat CLI entry in both sidebars. The result is a complete, navigable Talos API and CLI reference.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new structured navigation tree for Talos CLI reference documentation
  * Reorganized Talos API reference navigation to consolidate related items under a unified "API reference" category
  * Updated documentation structure across Talos Reference section for improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->