### PR TITLE
docs: shorten Talos announcement banner to one line

### DIFF
--- a/src/content/announcement-banner.mdx
+++ b/src/content/announcement-banner.mdx
@@ -4,4 +4,5 @@ export const announcement = {
   level: "info", // Visual emphasis: "info" | "warning" | "error" | "success"
 }
 
-Introducing Ory Talos — web-scale API Key server for secure (agentic) APIs. [Learn more](/docs/talos).
+Introducing Ory Talos — web-scale API Key server for secure (agentic) APIs.
+[Learn more](/docs/talos).

--- a/src/content/announcement-banner.mdx
+++ b/src/content/announcement-banner.mdx
@@ -4,9 +4,4 @@ export const announcement = {
   level: "info", // Visual emphasis: "info" | "warning" | "error" | "success"
 }
 
-We're happy to announce the release of our new product: Ory Talos - API Keys.
-Ory Talos secures automated workflows by turning static API keys into
-short-lived capability tokens for non-human identities. Using token derivation
-and Macaroon delegation, it enforces strict least-privilege guardrails.
-
-Learn more about [Ory Talos - API Keys](/docs/talos).
+Introducing Ory Talos — web-scale API Key server for secure (agentic) APIs. [Learn more](/docs/talos).


### PR DESCRIPTION
Shortens the Talos launch announcement banner from a multi-line paragraph to a single line to reduce vertical space.

**Before:** 3+ line paragraph.

**After:** `Introducing Ory Talos — web-scale API Key server for secure (agentic) APIs. [Learn more](/docs/talos).`

The `export const announcement` config block (enabled/id/level) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)