### PR TITLE
docs: document OIDC prompt=select_account value

### DIFF
--- a/docs/oauth2-oidc/authorization-code-flow.mdx
+++ b/docs/oauth2-oidc/authorization-code-flow.mdx
@@ -54,6 +54,9 @@ to the Authorization Server with the following parameters:
     already authenticated or has not already granted consent, the Authorization Server returns an error.
   - `login`: This value indicates that the Authorization Server should prompt the user to login before processing the access
     request.
+  - `select_account`: This value indicates that the Authorization Server should prompt the user to select a user account. Because
+    an Ory login session is tied to a single account, this behaves like `login`: the user is sent to the login screen, where they
+    can authenticate with the account of their choice.
   - `consent`: This value indicates that the Authorization Server should prompt the user to grant consent before processing the
     access request.
   - `registration`: This value indicates that the Authorization Server should display the registration UI instead of the login UI.


### PR DESCRIPTION
## Summary

Documents the new OpenID Connect `prompt=select_account` authorization-request value now accepted by Ory Hydra.

Previously the allowed `prompt` values were `none`, `login`, `consent`, and `registration`; requests using `select_account` were rejected with an `invalid_request` error. Because an Ory login session is tied to a single account, `select_account` is treated like `login`: the user is always sent to the login screen, where they can authenticate with the account of their choice.

This adds a `select_account` bullet to the `prompt` parameter list in `docs/oauth2-oidc/authorization-code-flow.mdx` (the only file that enumerates the supported prompt values), placed right after `login`.

## Related change

Documents the matching Hydra change: `fix(hydra): accept OpenID Connect prompt=select_account` (source PR link to follow).
