### PR TITLE
feat: add API reference and document orgs, auto-linking, mapping, and events

### DIFF
--- a/docs/kratos/manage-identities/50_scim.mdx
+++ b/docs/kratos/manage-identities/50_scim.mdx
@@ -57,12 +57,12 @@ SCIM in Ory Network is always scoped to an [organization](../organizations):
 Because of this, what happens when a SCIM client provisions a user (`POST /Users`) depends on whether a matching identity already
 exists, and which organization it belongs to:
 
-| Situation                                                                                   | Result                                                                                          |
-| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| No matching identity exists                                                                 | A new identity is created in the SCIM client's organization.                                    |
-| A matching identity exists **in the same organization**                                     | The existing identity is updated using the client's [data mapping](#data-mapping).              |
-| A matching identity exists **with no organization**, and a verified email domain matches    | The identity is linked into the organization and provisioning continues (see [Auto-linking](#auto-linking)). |
-| A matching identity exists **in a different organization**                                  | Provisioning fails with a `409 Conflict` error (see [Cross-organization conflicts](#cross-organization-conflicts)). |
+| Situation                                                                                | Result                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| No matching identity exists                                                              | A new identity is created in the SCIM client's organization.                                                        |
+| A matching identity exists **in the same organization**                                  | The existing identity is updated using the client's [data mapping](#data-mapping).                                  |
+| A matching identity exists **with no organization**, and a verified email domain matches | The identity is linked into the organization and provisioning continues (see [Auto-linking](#auto-linking)).        |
+| A matching identity exists **in a different organization**                               | Provisioning fails with a `409 Conflict` error (see [Cross-organization conflicts](#cross-organization-conflicts)). |
 
 ### Auto-linking
 
@@ -95,8 +95,7 @@ flowchart TD
 
 When the existing identity belongs to **no organization** and its verified email domain matches one of the organization's verified
 domains, it is adopted into the organization. This is useful when a user signed up (or was provisioned by SSO) before the
-organization started using SCIM. Any other cross-organization collision fails with a
-[conflict](#cross-organization-conflicts).
+organization started using SCIM. Any other cross-organization collision fails with a [conflict](#cross-organization-conflicts).
 
 ### Cross-organization conflicts
 
@@ -129,9 +128,8 @@ and provision identities.
 In the organization view, under **SCIM clients**, click **Add SCIM client**. This will open a form where you can configure your
 SCIM client's settings.
 
-- **Client ID**: Enter an identifier for your SCIM client. This identifier is part of the
-  [base URL](scim/api-reference#base-url) that the client uses to access the Ory Network SCIM server, so it should be unique
-  within your project.
+- **Client ID**: Enter an identifier for your SCIM client. This identifier is part of the [base URL](scim/api-reference#base-url)
+  that the client uses to access the Ory Network SCIM server, so it should be unique within your project.
 - **Label**: Enter a human-readable label for your SCIM client.
 - **Authorization header secret**: Enter a secret in the client authentication's **secret** field. Clients authenticate by sending
   this secret in the `Authorization` header of their requests. See [Authentication](scim/api-reference#authentication) for the
@@ -162,8 +160,8 @@ The SCIM data mapping uses the **same Jsonnet engine and the same output schema*
 - It additionally receives the existing identity in `std.extVar('identity')` (see below).
 
 The script must return a JSON object as defined in the [Jsonnet reference](../reference/jsonnet#output) — `identity.traits`,
-`identity.metadata_public`, `identity.metadata_admin`, and `identity.verified_addresses`. For the available SCIM input
-attributes, see the [user resource schema](scim/api-reference#user-resource-schema).
+`identity.metadata_public`, `identity.metadata_admin`, and `identity.verified_addresses`. For the available SCIM input attributes,
+see the [user resource schema](scim/api-reference#user-resource-schema).
 
 #### Preserving data with the `identity` variable
 
@@ -237,19 +235,19 @@ import DocCardList from '@theme/DocCardList';
 
 ## Events
 
-Ory Network emits events for SCIM operations that modify data. They surface in the Ory Console under **Activity** >
-**Logs & Events**, and can be used for auditing, automation, or integration with other systems.
+Ory Network emits events for SCIM operations that modify data. They surface in the Ory Console under **Activity** > **Logs &
+Events**, and can be used for auditing, automation, or integration with other systems.
 
-| SCIM action           | Events emitted                            | Description                                                                                                                                |
-| --------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `POST /Users`         | `IdentityCreated`                         | A new identity is provisioned. If the user is [auto-linked](#auto-linking) to an existing identity instead, `IdentityUpdated` is emitted. |
-| `PUT /Users/{id}`     | `IdentityUpdated`                         | An identity is replaced.                                                                                                                   |
-| `PATCH /Users/{id}`   | `IdentityUpdated`                         | An identity is partially updated.                                                                                                          |
-| `DELETE /Users/{id}`  | `IdentityDeleted`                         | An identity is deleted.                                                                                                                    |
-| `POST /Groups`        | `SCIMGroupCreated`                        | A new group is created.                                                                                                                    |
-| `PUT /Groups/{id}`    | `SCIMGroupUpdated` (+ `IdentityUpdated`)  | A group is replaced. See the note below about member events.                                                                               |
-| `PATCH /Groups/{id}`  | `SCIMGroupUpdated` (+ `IdentityUpdated`)  | A group is partially updated. See the note below about member events.                                                                      |
-| `DELETE /Groups/{id}` | `SCIMGroupDeleted` (+ `IdentityUpdated`)  | A group is deleted. See the note below about member events.                                                                                |
+| SCIM action           | Events emitted                           | Description                                                                                                                               |
+| --------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /Users`         | `IdentityCreated`                        | A new identity is provisioned. If the user is [auto-linked](#auto-linking) to an existing identity instead, `IdentityUpdated` is emitted. |
+| `PUT /Users/{id}`     | `IdentityUpdated`                        | An identity is replaced.                                                                                                                  |
+| `PATCH /Users/{id}`   | `IdentityUpdated`                        | An identity is partially updated.                                                                                                         |
+| `DELETE /Users/{id}`  | `IdentityDeleted`                        | An identity is deleted.                                                                                                                   |
+| `POST /Groups`        | `SCIMGroupCreated`                       | A new group is created.                                                                                                                   |
+| `PUT /Groups/{id}`    | `SCIMGroupUpdated` (+ `IdentityUpdated`) | A group is replaced. See the note below about member events.                                                                              |
+| `PATCH /Groups/{id}`  | `SCIMGroupUpdated` (+ `IdentityUpdated`) | A group is partially updated. See the note below about member events.                                                                     |
+| `DELETE /Groups/{id}` | `SCIMGroupDeleted` (+ `IdentityUpdated`) | A group is deleted. See the note below about member events.                                                                               |
 
 :::note
 
@@ -266,12 +264,12 @@ the failing request's status code and details.
 
 ### Event attributes
 
-| Event                                | Attribute                                                      | Description                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| All events                           | `SCIMClient`                                                  | The ID of the SCIM client that made the request.                                                           |
-| `IdentityCreated`, `IdentityUpdated` | `IdentityActive`                                              | Whether the identity is active (`true` or `false`).                                                        |
-| Group events                         | `SCIMGroupID`, `SCIMGroupExternalID`, `SCIMGroupDisplayName`  | Identify the group. `SCIMGroupUpdated` also includes `SCIMGroupAddedIdentityIDs` and `SCIMGroupRemovedIdentityIDs`. |
-| `SCIMProvisioningError`              | `SCIMErrorStatusCode`, `SCIMErrorStatusText`, `SCIMErrorDetail` | Describe the failure.                                                                                       |
+| Event                                | Attribute                                                       | Description                                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| All events                           | `SCIMClient`                                                    | The ID of the SCIM client that made the request.                                                                    |
+| `IdentityCreated`, `IdentityUpdated` | `IdentityActive`                                                | Whether the identity is active (`true` or `false`).                                                                 |
+| Group events                         | `SCIMGroupID`, `SCIMGroupExternalID`, `SCIMGroupDisplayName`    | Identify the group. `SCIMGroupUpdated` also includes `SCIMGroupAddedIdentityIDs` and `SCIMGroupRemovedIdentityIDs`. |
+| `SCIMProvisioningError`              | `SCIMErrorStatusCode`, `SCIMErrorStatusText`, `SCIMErrorDetail` | Describe the failure.                                                                                               |
 
 ## Limitations
 

--- a/docs/kratos/manage-identities/50_scim.mdx
+++ b/docs/kratos/manage-identities/50_scim.mdx
@@ -75,13 +75,28 @@ identity instead of creating a duplicate. A collision is detected by checking, i
 
 There is no matching on `externalId`.
 
-When a collision is found:
+When a collision is found, the outcome depends on the existing identity's organization:
 
-- If the existing identity is **already a member of the SCIM client's organization**, it is updated through the data mapping.
-- If the existing identity **belongs to no organization**, and it has a **verified email** whose domain matches one of the
-  organization's verified domains, the identity is linked into the organization and provisioning continues. This is useful when a
-  user signed up (or was provisioned by SSO) before the organization started using SCIM.
-- Otherwise — including when the existing identity belongs to a **different** organization — provisioning fails with a conflict.
+```mdx-code-block
+<Mermaid
+  chart={`
+flowchart TD
+    A([SCIM provisions a user]) --> B{Matching identity exists?}
+    B -->|No| C[Create new identity in the client's organization]
+    B -->|Yes| D{Existing identity's organization?}
+    D -->|Same as the SCIM client| E[Update the identity via the data mapping]
+    D -->|None| F{Verified email domain matches an org domain?}
+    D -->|Different organization| G[409 Conflict: identity already exists in another scope]
+    F -->|Yes| H[Link the identity into the organization and provision]
+    F -->|No| G
+`}
+/>
+```
+
+When the existing identity belongs to **no organization** and its verified email domain matches one of the organization's verified
+domains, it is adopted into the organization. This is useful when a user signed up (or was provisioned by SSO) before the
+organization started using SCIM. Any other cross-organization collision fails with a
+[conflict](#cross-organization-conflicts).
 
 ### Cross-organization conflicts
 

--- a/docs/kratos/manage-identities/50_scim.mdx
+++ b/docs/kratos/manage-identities/50_scim.mdx
@@ -188,8 +188,9 @@ organization is taken from the SCIM client's configuration, and `password` (if p
 :::note
 
 On multi-region Ory Network projects, provisioned identities (and their SCIM data) are stored in the same region as the identity.
-The mapper may set the region by returning an optional `identity.region` value; if it doesn't, the organization's default region
-is used. An invalid region value causes provisioning to fail with a `400` error.
+In addition to the standard [mapper output](../reference/jsonnet#output), the mapper may set the region by returning an optional
+`identity.region` field; if it doesn't, the organization's default region is used. An invalid region value causes provisioning to
+fail with a `400` error.
 
 :::
 

--- a/docs/kratos/manage-identities/50_scim.mdx
+++ b/docs/kratos/manage-identities/50_scim.mdx
@@ -18,11 +18,11 @@ organizations to automate the provisioning and de-provisioning of user accounts 
 burden and improving security.
 
 In Ory Network, SCIM is available at the organization level. This means that within one project, you can have multiple
-organizations with different SCIM configurations. Each organization can have its own SCIM settings, including the ability to
-enable or disable SCIM, set the base URL for SCIM endpoints, and configure authentication methods. This allows organizations to
-tailor their SCIM implementation to meet their specific needs and requirements.
+organizations with different SCIM configurations. Each organization can have one or more SCIM clients, each with its own endpoint
+URL, authentication secret, and data mapping. This allows organizations to tailor their SCIM implementation to meet their specific
+needs and requirements.
 
-Identities provisioned through the SCIM API are automatically created in Ory Network and added to that SCIM server's organization.
+Identities provisioned through the SCIM API are automatically created in Ory Network and added to that SCIM client's organization.
 The provisioned identities can then log in through any of the organization's configured SSO methods.
 
 ```mdx-code-block
@@ -42,6 +42,64 @@ flowchart TD
 />
 ```
 
+For the full endpoint reference — request and response shapes, pagination, filtering, and error responses — see the
+[SCIM API reference](scim/api-reference).
+
+## How SCIM relates to organizations
+
+SCIM in Ory Network is always scoped to an [organization](../organizations):
+
+- **Each SCIM client belongs to exactly one organization.** The organization is fixed when you create the client and determines
+  where provisioned identities are placed.
+- **An identity belongs to at most one organization.** An identity can be a member of a single organization or of none, but never
+  of two organizations at the same time.
+
+Because of this, what happens when a SCIM client provisions a user (`POST /Users`) depends on whether a matching identity already
+exists, and which organization it belongs to:
+
+| Situation                                                                                   | Result                                                                                          |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| No matching identity exists                                                                 | A new identity is created in the SCIM client's organization.                                    |
+| A matching identity exists **in the same organization**                                     | The existing identity is updated using the client's [data mapping](#data-mapping).              |
+| A matching identity exists **with no organization**, and a verified email domain matches    | The identity is linked into the organization and provisioning continues (see [Auto-linking](#auto-linking)). |
+| A matching identity exists **in a different organization**                                  | Provisioning fails with a `409 Conflict` error (see [Cross-organization conflicts](#cross-organization-conflicts)). |
+
+### Auto-linking
+
+When a SCIM client provisions a user that collides with an existing identity, Ory Network tries to link the SCIM record to that
+identity instead of creating a duplicate. A collision is detected by checking, in order:
+
+1. The login identifier (the identity's credentials identifier, typically derived from `userName`).
+2. A verified email address.
+3. A recovery address.
+
+There is no matching on `externalId`.
+
+When a collision is found:
+
+- If the existing identity is **already a member of the SCIM client's organization**, it is updated through the data mapping.
+- If the existing identity **belongs to no organization**, and it has a **verified email** whose domain matches one of the
+  organization's verified domains, the identity is linked into the organization and provisioning continues. This is useful when a
+  user signed up (or was provisioned by SSO) before the organization started using SCIM.
+- Otherwise — including when the existing identity belongs to a **different** organization — provisioning fails with a conflict.
+
+### Cross-organization conflicts
+
+Because an identity can only belong to one organization, provisioning a user who already exists in a **different** organization
+fails with a `409 Conflict`:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "status": "409",
+  "scimType": "uniqueness",
+  "detail": "Could not create user: identity already exists in another scope"
+}
+```
+
+To resolve this, either delete the existing identity, or move it into the target organization, before retrying provisioning. See
+the [API reference](scim/api-reference#errors) for the full error model.
+
 ## Set up identity provisioning with SCIM
 
 To set up identity provisioning with SCIM, follow these steps:
@@ -56,53 +114,104 @@ and provision identities.
 In the organization view, under **SCIM clients**, click **Add SCIM client**. This will open a form where you can configure your
 SCIM client's settings.
 
-- **Client ID**: Enter an identifier for your SCIM client. This identifier will be part of the URL the client uses to access the
-  Ory Network SCIM server. It should be unique within your project.
+- **Client ID**: Enter an identifier for your SCIM client. This identifier is part of the
+  [base URL](scim/api-reference#base-url) that the client uses to access the Ory Network SCIM server, so it should be unique
+  within your project.
 - **Label**: Enter a human-readable label for your SCIM client.
-- **Authorization header secret**: Enter a secret in the client authentication's **secret** field. This secret will be used to
-  authenticate requests to the SCIM server. Clients need to specify this in the `Authorization` header of their requests.
-- **Data mapping**: When the client creates or updates a user, the supplied data will be applied to the identity based on this
-  data mapping. See below for more details.
+- **Authorization header secret**: Enter a secret in the client authentication's **secret** field. Clients authenticate by sending
+  this secret in the `Authorization` header of their requests. See [Authentication](scim/api-reference#authentication) for the
+  exact header format.
+- **Data mapping**: When the client creates or updates a user, the supplied data is applied to the identity based on this data
+  mapping. See [Data mapping](#data-mapping) below.
+
+Once the client is created, the Console shows its SCIM server URL. Configure your identity provider to send SCIM requests to that
+URL, using the authorization header secret as its token.
 
 ### Data mapping
 
-The data mapping is a Jsonnet script that defines how the data the SCIM client sends should be mapped to the identity in the Ory
-Network. This mapping will be applied any time the SCIM client creates or updates a user (`POST`, `PATCH`, or `PUT`), and the
-identity will be updated accordingly. However, the mapping is unidirectional. For example, if the user updates an identity trait
-that was previously set by the SCIM client, the SCIM client will not be able to retrieve the updated value.
+The data mapping is a [Jsonnet](../reference/jsonnet) script that defines how the data the SCIM client sends is mapped to the
+identity in Ory Network. This mapping is applied any time the SCIM client creates or updates a user (`POST`, `PATCH`, or `PUT`),
+and the identity is updated accordingly.
 
-In the context of the Jsonnet script, the SCIM user data is available as `std.extVar('scim')`. For the available attributes, refer
-to the [SCIM user resource schema](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1) or the documentation below.
+The mapping is **unidirectional**: it only runs when the SCIM client writes data. If an identity trait is later changed elsewhere
+(for example by the user or another SSO method), the SCIM client cannot read the updated value back. On read (`GET`), the SCIM
+attributes are returned from the data stored at provisioning time, not re-derived from the identity.
 
-The script should return a JSON object as defined in the [Jsonnet reference](../reference/jsonnet#output).
+#### Relationship to the OIDC and SAML Jsonnet mapper
 
-The SCIM provisioning data mapper also receives the existing `identity` (if present) through a new identity external variable,
-alongside the existing scim variable. It exposes traits, metadata_public, and metadata_admin, each defaulting to an empty object
-when unset.
+The SCIM data mapping uses the **same Jsonnet engine and the same output schema** as the
+[OIDC and SAML SSO data mapping](../reference/jsonnet). The differences are:
 
-This lets a mapper preserve or merge attributes that SCIM does not manage. A mapper can now merge them back in:
+- It is configured **per SCIM client** (each client has its own mapper), not per SSO provider.
+- The input is the SCIM payload in `std.extVar('scim')` instead of OIDC `claims` or SAML attributes.
+- It additionally receives the existing identity in `std.extVar('identity')` (see below).
 
-```
+The script must return a JSON object as defined in the [Jsonnet reference](../reference/jsonnet#output) — `identity.traits`,
+`identity.metadata_public`, `identity.metadata_admin`, and `identity.verified_addresses`. For the available SCIM input
+attributes, see the [user resource schema](scim/api-reference#user-resource-schema).
+
+#### Preserving data with the `identity` variable
+
+The mapper also receives the existing `identity` (if one exists) through the `std.extVar('identity')` variable, alongside the
+`scim` variable. It exposes `traits`, `metadata_public`, and `metadata_admin`, each defaulting to an empty object when unset.
+
+This matters because the mapping uses **full-replace** semantics: the object your script returns overwrites the corresponding
+identity fields. If you map `metadata_public` without merging the existing values back in, any metadata that SCIM does not manage
+(for example an `oid` set by SAML or OIDC SSO) is lost on the next sync. To preserve it, merge the existing value:
+
+```jsonnet
 local scim = std.extVar('scim');
 local identity = std.extVar('identity');
 local existingPublic = std.get(identity, 'metadata_public', {});
 
 {
   identity: {
-    ...
-    metadata_public: existingMetadata + {
-      // Add or override only what SCIM should manage
+    traits: {
+      email: scim.userName,
+    },
+    // Keep metadata SCIM does not manage (for example values set by OIDC/SAML SSO),
+    // and override only what SCIM should manage.
+    metadata_public: existingPublic + {
+      // Add or override only what SCIM should manage here.
     },
   },
 }
 ```
 
-### Use the SCIM client
+:::note
 
-Once you have configured a SCIM client, you can use it to provision identities. The Ory Network SCIM server provides a set of
-endpoints that allow the creation and management of user identities and groups.
+A few attributes are applied directly and are not controlled by the mapping: `active` sets whether the identity can log in, the
+organization is taken from the SCIM client's configuration, and `password` (if present) is stored as a password credential.
 
-Please refer to these guides for setting up SCIM with specific identity providers:
+:::
+
+:::note
+
+On multi-region Ory Network projects, provisioned identities (and their SCIM data) are stored in the same region as the identity.
+The mapper may set the region by returning an optional `identity.region` value; if it doesn't, the organization's default region
+is used. An invalid region value causes provisioning to fail with a `400` error.
+
+:::
+
+## Deprovisioning identities
+
+There are two distinct ways to remove access, with different effects:
+
+- **Deactivate**: set `active` to `false` (for example through `PATCH /Users/{id}`). The identity is kept but cannot log in. This
+  is reversible — set `active` back to `true` to restore access.
+- **Delete**: `DELETE /Users/{id}` **permanently deletes the underlying Ory identity** and returns `204 No Content`. This cannot
+  be undone.
+
+Most identity providers map a user being unassigned or disabled to a deactivation rather than a deletion. Check your provider's
+configuration to confirm which behavior it uses.
+
+## Use the SCIM client
+
+Once you have configured a SCIM client, you can use it to provision identities. The Ory Network SCIM server exposes endpoints for
+managing users and groups, service-discovery endpoints, pagination, and filtering — all documented in the
+[SCIM API reference](scim/api-reference).
+
+Refer to these guides for setting up SCIM with specific identity providers:
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
@@ -110,109 +219,49 @@ import DocCardList from '@theme/DocCardList';
 <DocCardList />
 ```
 
-For generic SCIM clients, the following endpoints are available:
-
-- **User endpoints**
-  - `GET /Users`: Retrieve a list of users.
-  - `POST /Users`: Create a new user.
-  - `GET /Users/{id}`: Retrieve a specific user by ID.
-  - `PUT /Users/{id}`: Update a specific user by ID.
-  - `PATCH /Users/{id}`: Partially update a specific user by ID.
-  - `DELETE /Users/{id}`: Delete a specific user by ID.
-- **Group endpoints**
-  - `GET /Groups`: Retrieve a list of groups.
-  - `POST /Groups`: Create a new group.
-  - `GET /Groups/{id}`: Retrieve a specific group by ID.
-  - `PUT /Groups/{id}`: Update a specific group by ID.
-  - `PATCH /Groups/{id}`: Partially update a specific group by ID.
-  - `DELETE /Groups/{id}`: Delete a specific group by ID.
-
-### SCIM resource schemas
-
-For programmatic discovery of the SCIM resource schemas, you can use the `GET /Schemas` endpoint. This will return a list of all
-available schemas.
-
-### SCIM user resource schema
-
-Ory Network fully supports the standard SCIM user resource schema as defined in the
-[SCIM RFC](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1). In detail, the following attributes are supported:
-
-| Name                | Type   | Remarks                                                                                                                                                                                               |
-| ------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                | UUID   | Read-only, this is the identity ID.                                                                                                                                                                   |
-| `externalId`        | string | Optional, an ID set by the SCIM client.                                                                                                                                                               |
-| `userName`          | string | Required, unique identifier for the user. Typically used as the login identifier.                                                                                                                     |
-| `name`              | object | Contains sub-attributes `formatted`, `familyName`, `givenName`, `middleName`, `honorificPrefix`, and `honorificSuffix`.                                                                               |
-| `displayName`       | string |                                                                                                                                                                                                       |
-| `nickName`          | string |                                                                                                                                                                                                       |
-| `profileUrl`        | string |                                                                                                                                                                                                       |
-| `title`             | string |                                                                                                                                                                                                       |
-| `userType`          | string |                                                                                                                                                                                                       |
-| `preferredLanguage` | string |                                                                                                                                                                                                       |
-| `locale`            | string |                                                                                                                                                                                                       |
-| `timeZone`          | string | If set, must be a valid time zone.                                                                                                                                                                    |
-| `active`            | bool   | If unset or false, the user will not be able to log in.                                                                                                                                               |
-| `password`          | string | If set, the user will be able to log in with this password. The password is never returned in any SCIM response.                                                                                      |
-| `emails`            | array  | List of email addresses. Each email can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` email can be set.                           |
-| `phoneNumbers`      | array  | List of phone numbers. Each number can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` number can be set.                           |
-| `ims`               | array  | List of instant messaging accounts. Each account can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` account can be set.            |
-| `photos`            | array  | List of photos. Each photo can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` photo can be set.                                    |
-| `addresses`         | array  | List of addresses. Each address can have a `formatted` (string), `streetAddress` (string), `locality` (string), `region` (string), `postalCode` (string), `country` (string), and `type` (string).    |
-| `groups`            | array  | Read-only, a list of groups the user is a member of. Each group can have a `value` (string), `display` (string), and `type` (string). To modify, set the `members` property on the `groups` resource. |
-| `entitlements`      | array  | List of entitlements. Each entitlement can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` entitlement can be set.                  |
-| `roles`             | array  | List of roles. Each role can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` role can be set.                                       |
-| `x509Certificates`  | array  | List of X.509 certificates. Each certificate can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` certificate can be set.            |
-
-### SCIM group resource schema
-
-Ory Network fully supports the standard SCIM group resource schema as defined in the
-[SCIM RFC](https://datatracker.ietf.org/doc/html/rfc7643#section-4.2). In detail, the following attributes are supported:
-
-| Name          | Type   | Remarks                                                                                                                                                                                                         |
-| ------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | UUID   | Read-only, this is the group ID.                                                                                                                                                                                |
-| `externalId`  | string | Optional, an ID set by the SCIM client. If set, this ID must be unique in the context of the organization.                                                                                                      |
-| `displayName` | string | Required, the name of the group.                                                                                                                                                                                |
-| `members`     | array  | List of members. Each member can have a `value` (string), `display` (string), and `type` (string). `value` is either an identity ID (when `type` equals `"User"`) or a group ID (when `type` equals `"Group"`). |
-
-### Group memberships
-
-The SCIM server supports group memberships. To update group memberships, use the `members` property on the `Groups` resource.
-Groups also support nested sub-groups. However, in the user resource, only the direct group memberships are included.
-
 ## Events
 
-Ory Network emits events for all SCIM operations that modify data. These events allow you to track and respond to changes in your
-identity ecosystem.
+Ory Network emits events for SCIM operations that modify data. They surface in the Ory Console under **Activity** >
+**Logs & Events**, and can be used for auditing, automation, or integration with other systems.
 
-| SCIM Action           | Events Emitted                 | Description                                                              |
-| --------------------- | ------------------------------ | ------------------------------------------------------------------------ |
-| `POST /Users`         | IdentityCreated                | Emitted when a new identity is provisioned                               |
-| `PUT /Users/{id}`     | IdentityUpdated                | Emitted when an identity is updated                                      |
-| `PATCH /Users/{id}`   | IdentityUpdated                | Emitted when an identity is partially updated                            |
-| `DELETE /Users/{id}`  | IdentityDeleted                | Emitted when an identity is deleted                                      |
-| `POST /Groups`        | GroupCreated                   | Emitted when a new group is created                                      |
-| `PUT /Groups/{id}`    | GroupUpdated + IdentityUpdated | Emitted when a group is updated, for the group and all members           |
-| `PATCH /Groups/{id}`  | GroupUpdated + IdentityUpdated | Emitted when a group is partially updated, for the group and all members |
-| `DELETE /Groups/{id}` | GroupDeleted + IdentityUpdated | Emitted when a group is deleted, for the group and all members           |
+| SCIM action           | Events emitted                            | Description                                                                                                                                |
+| --------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `POST /Users`         | `IdentityCreated`                         | A new identity is provisioned. If the user is [auto-linked](#auto-linking) to an existing identity instead, `IdentityUpdated` is emitted. |
+| `PUT /Users/{id}`     | `IdentityUpdated`                         | An identity is replaced.                                                                                                                   |
+| `PATCH /Users/{id}`   | `IdentityUpdated`                         | An identity is partially updated.                                                                                                          |
+| `DELETE /Users/{id}`  | `IdentityDeleted`                         | An identity is deleted.                                                                                                                    |
+| `POST /Groups`        | `SCIMGroupCreated`                        | A new group is created.                                                                                                                    |
+| `PUT /Groups/{id}`    | `SCIMGroupUpdated` (+ `IdentityUpdated`)  | A group is replaced. See the note below about member events.                                                                               |
+| `PATCH /Groups/{id}`  | `SCIMGroupUpdated` (+ `IdentityUpdated`)  | A group is partially updated. See the note below about member events.                                                                      |
+| `DELETE /Groups/{id}` | `SCIMGroupDeleted` (+ `IdentityUpdated`)  | A group is deleted. See the note below about member events.                                                                                |
+
+:::note
+
+The `IdentityUpdated` events on group operations are only emitted when the client's [data mapping](#data-mapping) derives identity
+data from group membership. In that case, an `IdentityUpdated` event is emitted for each affected member whose mapped data
+actually changes — the members added to or removed from the group (for `PUT` and `PATCH`), or all former members (for `DELETE`).
+If the mapping does not use group membership, group operations emit only the group event.
+
+:::
+
+In addition, a `SCIMProvisioningError` event is emitted whenever a request fails. This is the **SCIM provisioning error** entry
+under **Activity** > **Logs & Events** that the [provider guides](#use-the-scim-client) point to for troubleshooting; it carries
+the failing request's status code and details.
 
 ### Event attributes
 
-| Event Type                       | Attribute        | Description                                                      |
-| -------------------------------- | ---------------- | ---------------------------------------------------------------- |
-| All events                       | `ScimClient`     | Contains the ID of the SCIM client that made the request         |
-| IdentityCreated, IdentityUpdated | `IdentityActive` | Boolean indicating if the identity is active (`true` or `false`) |
+| Event                                | Attribute                                                      | Description                                                                                                |
+| ------------------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| All events                           | `SCIMClient`                                                  | The ID of the SCIM client that made the request.                                                           |
+| `IdentityCreated`, `IdentityUpdated` | `IdentityActive`                                              | Whether the identity is active (`true` or `false`).                                                        |
+| Group events                         | `SCIMGroupID`, `SCIMGroupExternalID`, `SCIMGroupDisplayName`  | Identify the group. `SCIMGroupUpdated` also includes `SCIMGroupAddedIdentityIDs` and `SCIMGroupRemovedIdentityIDs`. |
+| `SCIMProvisioningError`              | `SCIMErrorStatusCode`, `SCIMErrorStatusText`, `SCIMErrorDetail` | Describe the failure.                                                                                       |
 
-These events provide visibility into all SCIM-related changes and can be used for auditing, automation, or integration with other
-systems in your organization.
+## Limitations
 
-## Known limitations
+The SCIM server advertises its capabilities through `GET /ServiceProviderConfig`. Notable limitations to be aware of:
 
-- When querying users with `GET /Users`, the SCIM server only supports the `eq` operator for filtering, and only with the
-  `userName` or `externalId` attribute. Other operators like `ne`, `co`, `sw`, and `ew` are not supported.
-- When querying groups with `GET /Groups`, the SCIM server only supports the `eq` operator for filtering, and only with the
-  `displayName` or `externalId` attribute. Other operators like `ne`, `co`, `sw`, and `ew` are not supported.
-- For both user and group query endpoints, `startIndex` must be lower than 5000, and `count` must be lower than 1000.
-- If a user already exists within the same organization, SCIM provisioning will update the user using the configured data mapper.
-  However, if the user exists in a different organization, provisioning may fail with a 409 Conflict error. In this case, you must
-  either: manually delete the existing user, or move the user into the target organization before retrying provisioning.
+- Filtering supports only the `eq` operator, and only on a small set of indexed attributes. See
+  [Filtering](scim/api-reference#filtering).
+- Sorting, ETag/versioning, bulk operations, and a `/Me` endpoint are not supported. See
+  [Supported features](scim/api-reference#supported-features).

--- a/docs/kratos/manage-identities/scim/api-reference.mdx
+++ b/docs/kratos/manage-identities/scim/api-reference.mdx
@@ -1,0 +1,523 @@
+---
+id: api-reference
+title: SCIM API reference
+sidebar_label: API reference
+---
+
+# SCIM API reference
+
+```mdx-code-block
+import Help from '@site/docs/_common/need-help.mdx'
+
+<Help/>
+```
+
+This page is a reference for the Ory Network SCIM server API. It describes the base URL and authentication, every available
+endpoint with example requests and responses, the supported resource schemas, pagination and filtering, and the error model.
+
+For a conceptual overview, how SCIM relates to organizations, auto-linking, and data mapping, see the
+[SCIM overview](../scim).
+
+The Ory Network SCIM server implements SCIM 2.0 as defined in [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643)
+(schemas) and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) (protocol), with cursor-based pagination from
+[RFC 9865](https://datatracker.ietf.org/doc/html/rfc9865).
+
+## Base URL
+
+Each SCIM client has its own base URL. The client ID you choose when configuring the SCIM client is part of the URL:
+
+```
+https://<project-slug>.projects.oryapis.com/scim/<client-id>/v2
+```
+
+The exact URL is shown in the Ory Console when you create or edit a SCIM client. All endpoint paths below are relative to this
+base URL — for example, `POST /Users` means
+`POST https://<project-slug>.projects.oryapis.com/scim/<client-id>/v2/Users`.
+
+The server returns `Content-Type: application/scim+json` on every response. Send the same content type on requests that have a
+body.
+
+## Authentication
+
+Every request must include an `Authorization` header that matches the **Authorization header secret** configured on the SCIM
+client. The server compares the header against the configured secret using a constant-time comparison.
+
+```
+Authorization: Bearer <your-secret>
+```
+
+When comparing, the server trims surrounding whitespace and strips a single leading, case-insensitive `Bearer ` prefix. This
+means that if your configured secret is `s3cr3t`, both of the following are accepted:
+
+- `Authorization: Bearer s3cr3t`
+- `Authorization: s3cr3t`
+
+:::info
+
+Some identity providers (for example Microsoft Entra) ask you to enter the token **without** the `Bearer` prefix and add it
+themselves. Because only one `Bearer ` prefix is stripped, configure the secret without a `Bearer ` prefix to avoid
+double-prefixing. See the [provider guides](../scim#use-the-scim-client) for provider-specific instructions.
+
+:::
+
+Authentication errors:
+
+| Condition                       | Status | `detail`                        |
+| ------------------------------- | ------ | ------------------------------- |
+| No `Authorization` header       | `401`  | `no authorization header found` |
+| Header does not match the secret| `401`  | `invalid authorization header`  |
+
+:::note
+
+`ServiceProviderConfig` advertises `httpbasic` as the authentication scheme for SCIM-discovery compatibility, but
+authentication is performed against the shared secret in the `Authorization` header as described above.
+
+:::
+
+## Service discovery
+
+These read-only endpoints let SCIM clients and conformance tools discover the server's capabilities. They do not require a
+resource ID.
+
+| Method | Path                          | Description                                              |
+| ------ | ----------------------------- | -------------------------------------------------------- |
+| `GET`  | `/ServiceProviderConfig`      | Server capabilities (patch, filter, pagination, auth)    |
+| `GET`  | `/ResourceTypes`              | List of supported resource types (`User`, `Group`)       |
+| `GET`  | `/ResourceTypes/{id}`         | A single resource type, where `id` is `User` or `Group`  |
+| `GET`  | `/Schemas`                    | List of supported schemas (User, Group, Enterprise User) |
+| `GET`  | `/Schemas/{id}`               | A single schema, where `id` is the schema URN            |
+
+### GET /ServiceProviderConfig
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+  "documentationUri": "https://www.ory.com/docs/kratos/manage-identities/scim",
+  "patch": { "supported": true },
+  "bulk": { "supported": false },
+  "filter": { "supported": true, "maxResults": 1000 },
+  "changePassword": { "supported": true },
+  "sort": { "supported": false },
+  "etag": { "supported": false },
+  "pagination": {
+    "cursor": true,
+    "index": true,
+    "defaultPaginationMethod": "index",
+    "defaultPageSize": 100,
+    "maxPageSize": 1000,
+    "cursorTimeout": 3600
+  },
+  "authenticationSchemes": [
+    {
+      "type": "httpbasic",
+      "name": "HTTP Basic Authentication",
+      "description": "Authentication through a shared secret in the Authorization HTTP header.",
+      "specUri": "https://datatracker.ietf.org/doc/rfc7617/",
+      "documentationUri": "https://www.ory.com/docs/kratos/manage-identities/scim#configure-a-scim-client"
+    }
+  ],
+  "meta": { "resourceType": "ServiceProviderConfig" }
+}
+```
+
+## Users
+
+| Method   | Path           | Description                          | Success status |
+| -------- | -------------- | ------------------------------------ | -------------- |
+| `GET`    | `/Users`       | List or search users                 | `200`          |
+| `POST`   | `/Users`       | Create a user                        | `201`          |
+| `GET`    | `/Users/{id}`  | Retrieve a user by ID                | `200`          |
+| `PUT`    | `/Users/{id}`  | Replace a user (full update)         | `200`          |
+| `PATCH`  | `/Users/{id}`  | Partially update a user (PatchOp)    | `200`          |
+| `DELETE` | `/Users/{id}`  | Delete a user (deletes the identity) | `204`          |
+
+The `{id}` is the Ory identity ID (a UUID), returned as `id` when the user is created.
+
+### Create a user
+
+```http
+POST /Users
+Content-Type: application/scim+json
+Authorization: Bearer <your-secret>
+```
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "externalId": "ext-123",
+  "userName": "bjensen@example.com",
+  "name": { "givenName": "Barbara", "familyName": "Jensen" },
+  "emails": [{ "value": "bjensen@example.com", "primary": true, "type": "work" }],
+  "active": true
+}
+```
+
+On success the server responds with `201 Created` and the full user resource:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210",
+  "externalId": "ext-123",
+  "userName": "bjensen@example.com",
+  "name": { "givenName": "Barbara", "familyName": "Jensen" },
+  "active": true,
+  "emails": [{ "value": "bjensen@example.com", "primary": true, "type": "work" }],
+  "groups": [],
+  "meta": {
+    "resourceType": "User",
+    "created": "2026-06-15T10:00:00Z",
+    "lastModified": "2026-06-15T10:00:00Z"
+  }
+}
+```
+
+How the incoming attributes are applied to the Ory identity is controlled by the client's
+[data mapping](../scim#data-mapping). The `password` attribute, if present, is stored as a password credential and is never
+returned in any response.
+
+If the user already exists, the create may succeed as an update (auto-linking) or fail with a `409` conflict. See
+[How SCIM relates to organizations](../scim#how-scim-relates-to-organizations) and [Errors](#errors).
+
+### Retrieve a user
+
+```http
+GET /Users/9f8e7d6c-5b4a-3210-fedc-ba9876543210
+```
+
+Returns `200 OK` and the user resource shown above.
+
+### List users
+
+```http
+GET /Users?startIndex=1&count=20
+```
+
+Returns a `ListResponse` envelope. See [Pagination](#pagination) for the offset and cursor variants and
+[Filtering](#filtering) for the `filter` query parameter.
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 42,
+  "startIndex": 1,
+  "itemsPerPage": 20,
+  "Resources": [
+    { "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "id": "...", "userName": "bjensen@example.com", "active": true }
+  ]
+}
+```
+
+### Replace a user
+
+`PUT /Users/{id}` replaces the user with the supplied representation. Attributes that are not present in the request are reset to
+their default. Use `PATCH` for partial updates.
+
+### Update a user (PATCH)
+
+`PATCH /Users/{id}` applies a SCIM [PatchOp](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2) with `add`, `replace`,
+and `remove` operations:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    { "op": "replace", "path": "active", "value": false },
+    { "op": "replace", "path": "name.givenName", "value": "Babs" }
+  ]
+}
+```
+
+- Schema-qualified attribute paths are accepted, for example
+  `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`. Paths that reference an unsupported schema return
+  `400`.
+- A `remove` operation without a `path` returns `400` with `scimType: noTarget`.
+- Operations against read-only attributes (such as `id`, `groups`, or `meta`) are ignored.
+
+### Delete a user
+
+`DELETE /Users/{id}` returns `204 No Content` and **permanently deletes the underlying Ory identity**. To disable a user without
+deleting it, set `active` to `false` instead. See [Deprovisioning identities](../scim#deprovisioning-identities).
+
+### User resource schema
+
+Ory Network supports the standard SCIM user resource schema as defined in
+[RFC 7643, Section 4.1](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1). The following attributes are supported:
+
+| Name                | Type   | Remarks                                                                                                                                                                                               |
+| ------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                | UUID   | Read-only, this is the identity ID.                                                                                                                                                                   |
+| `externalId`        | string | Optional, an ID set by the SCIM client. Filterable (case-sensitive).                                                                                                                                  |
+| `userName`          | string | Required, unique identifier for the user. Typically used as the login identifier. Filterable.                                                                                                         |
+| `name`              | object | Contains sub-attributes `formatted`, `familyName`, `givenName`, `middleName`, `honorificPrefix`, and `honorificSuffix`.                                                                               |
+| `displayName`       | string |                                                                                                                                                                                                       |
+| `nickName`          | string |                                                                                                                                                                                                       |
+| `profileUrl`        | string |                                                                                                                                                                                                       |
+| `title`             | string |                                                                                                                                                                                                       |
+| `userType`          | string |                                                                                                                                                                                                       |
+| `preferredLanguage` | string |                                                                                                                                                                                                       |
+| `locale`            | string |                                                                                                                                                                                                       |
+| `timezone`          | string | If set, must be a valid time zone.                                                                                                                                                                    |
+| `active`            | bool   | Whether the user can log in. **If omitted on create or replace, defaults to `true`.** Set to `false` to deactivate the user; deactivated users cannot log in.                                          |
+| `password`          | string | If set, the user can log in with this password. The password is never returned in any SCIM response.                                                                                                  |
+| `emails`            | array  | List of email addresses. Each email can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` email can be set.                           |
+| `phoneNumbers`      | array  | List of phone numbers. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                     |
+| `ims`               | array  | List of instant messaging accounts. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                        |
+| `photos`            | array  | List of photos. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                            |
+| `addresses`         | array  | List of addresses. Each address can have `formatted`, `streetAddress`, `locality`, `region`, `postalCode`, `country`, and `type`.                                                                     |
+| `groups`            | array  | Read-only, a list of groups the user is a direct member of. Each entry has `value`, `display`, and `type`. To modify, set the `members` property on the `Groups` resource.                            |
+| `entitlements`      | array  | List of entitlements. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                      |
+| `roles`             | array  | List of roles. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                             |
+| `x509Certificates`  | array  | List of X.509 certificates. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                |
+
+### Enterprise User extension
+
+The server supports the SCIM Enterprise User extension
+([RFC 7643, Section 4.3](https://datatracker.ietf.org/doc/html/rfc7643#section-4.3)), identified by the schema URN
+`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`. When present, the extension is returned as a top-level object keyed
+by the URN, and the URN is added to the resource's `schemas` array:
+
+```json
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:User",
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+  ],
+  "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210",
+  "userName": "bjensen@example.com",
+  "active": true,
+  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+    "employeeNumber": "701984",
+    "costCenter": "4130",
+    "organization": "Universal Studios",
+    "division": "Theme Park",
+    "department": "Tour Operations",
+    "manager": { "value": "<manager-identity-id>", "displayName": "John Smith" }
+  }
+}
+```
+
+| Name             | Type   | Remarks                                                                                                                  |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `employeeNumber` | string | Filterable.                                                                                                              |
+| `costCenter`     | string |                                                                                                                          |
+| `organization`   | string | A free-form string attribute; unrelated to the Ory organization the SCIM client is bound to.                            |
+| `division`       | string |                                                                                                                          |
+| `department`     | string |                                                                                                                          |
+| `manager`        | object | `value` is the manager's identity ID. `manager.displayName` is read-only and is only resolved if the manager identity is in the same organization. |
+
+## Groups
+
+| Method   | Path            | Description                       | Success status |
+| -------- | --------------- | --------------------------------- | -------------- |
+| `GET`    | `/Groups`       | List or search groups             | `200`          |
+| `POST`   | `/Groups`       | Create a group                    | `201`          |
+| `GET`    | `/Groups/{id}`  | Retrieve a group by ID            | `200`          |
+| `PUT`    | `/Groups/{id}`  | Replace a group (full update)     | `200`          |
+| `PATCH`  | `/Groups/{id}`  | Partially update a group (PatchOp)| `200`          |
+| `DELETE` | `/Groups/{id}`  | Delete a group                    | `204`          |
+
+### Create a group
+
+```http
+POST /Groups
+Content-Type: application/scim+json
+Authorization: Bearer <your-secret>
+```
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+  "externalId": "ext-grp-1",
+  "displayName": "Engineering",
+  "members": [
+    { "value": "<identity-id>", "type": "User" },
+    { "value": "<group-id>", "type": "Group" }
+  ]
+}
+```
+
+Returns `201 Created` with the group resource:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+  "id": "a1b2c3d4-...",
+  "externalId": "ext-grp-1",
+  "displayName": "Engineering",
+  "members": [
+    { "value": "<identity-id>", "display": "bjensen@example.com", "type": "User" },
+    { "value": "<group-id>", "display": "Backend", "type": "Group" }
+  ],
+  "meta": {
+    "resourceType": "Group",
+    "created": "2026-06-15T10:00:00Z",
+    "lastModified": "2026-06-15T10:00:00Z"
+  }
+}
+```
+
+### Group memberships
+
+Group memberships are managed through the `members` attribute on the `Groups` resource. Each member entry has:
+
+- `value`: an identity ID when `type` is `"User"`, or a group ID when `type` is `"Group"` (nested sub-groups are supported).
+- `type`: `"User"` or `"Group"`.
+- `display`: read-only, the member's `userName` (for users) or group name (for groups).
+
+The `groups` attribute on a user resource reflects only the user's **direct** memberships and is read-only.
+
+To change memberships incrementally, use `PATCH /Groups/{id}` with `add` and `remove` operations targeting the `members` path.
+A `remove` without a `path` returns `400 noTarget` rather than removing all members.
+
+### Group resource schema
+
+Ory Network supports the standard SCIM group resource schema as defined in
+[RFC 7643, Section 4.2](https://datatracker.ietf.org/doc/html/rfc7643#section-4.2):
+
+| Name          | Type   | Remarks                                                                                                                       |
+| ------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `id`          | UUID   | Read-only, this is the group ID.                                                                                              |
+| `externalId`  | string | Optional, an ID set by the SCIM client. If set, it must be unique within the organization. Filterable.                        |
+| `displayName` | string | Required, the name of the group. Filterable.                                                                                  |
+| `members`     | array  | List of members. Each member has `value`, `display` (read-only), and `type` (`"User"` or `"Group"`). See above.               |
+
+## Pagination
+
+The list endpoints (`GET /Users` and `GET /Groups`) support two mutually exclusive pagination methods. Offset-based pagination is
+the default; cursor-based pagination is used when a `cursor` query parameter is present.
+
+### Offset-based pagination (default)
+
+Uses the standard SCIM `startIndex` (1-based) and `count` query parameters.
+
+| Parameter    | Default | Limit               |
+| ------------ | ------- | ------------------- |
+| `startIndex` | `1`     | must be ≤ `5000`    |
+| `count`      | `100`   | must be ≤ `1000`    |
+
+`startIndex` or `count` above the limit returns `400` with `scimType: tooMany`. A `count` of `0` returns only `totalResults`
+with no `Resources` array. Offset responses always include `totalResults` (including `0`):
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 42,
+  "startIndex": 1,
+  "itemsPerPage": 20,
+  "Resources": [ ]
+}
+```
+
+### Cursor-based pagination
+
+For large result sets, use keyset (cursor) pagination as defined in
+[RFC 9865](https://datatracker.ietf.org/doc/html/rfc9865). Start by passing `cursor` with an empty value (or a known cursor),
+then follow `nextCursor` from each response until it is no longer returned:
+
+```http
+GET /Users?count=20&cursor=
+```
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "itemsPerPage": 20,
+  "nextCursor": "<opaque-encrypted-cursor>",
+  "Resources": [ ]
+}
+```
+
+- Results are ordered by `id`.
+- Cursors are opaque, stateless tokens that **expire after one hour** (`cursorTimeout` in `ServiceProviderConfig`). An expired
+  cursor returns `400` with `scimType: expiredCursor`; an invalid cursor returns `400` with `scimType: invalidCursor`. In both
+  cases, restart pagination from the first page.
+- `nextCursor` is omitted on the last page.
+- `totalResults` is **not** returned on cursor pages.
+
+## Filtering
+
+The list endpoints accept a `filter` query parameter. Only the `eq` (equals) operator is supported, and only on indexed
+attributes:
+
+| Resource | Filterable attributes                                              |
+| -------- | ------------------------------------------------------------------ |
+| Users    | `userName`, `externalId`, `employeeNumber`, `groups.value` (a group UUID) |
+| Groups   | `displayName`, `externalId`                                        |
+
+```http
+GET /Users?filter=userName eq "bjensen@example.com"
+```
+
+- `externalId` filtering is case-sensitive.
+- Filtering on any other attribute returns `400` with `scimType: invalidFilter` ("not indexed").
+- Other operators (`ne`, `co`, `sw`, `ew`, `pr`, `gt`, and so on) are not supported.
+- A `filter` may reference a supported schema URN prefix; references to unsupported schemas return `400`.
+- The `filter` query string is limited to 1024 bytes.
+
+## Attribute selection
+
+The `attributes` and `excludedAttributes` query parameters control which attributes are returned. Only one of the two may be set
+in a single request; setting both returns `400`.
+
+## Errors
+
+Errors are returned with an appropriate HTTP status code and a SCIM error body
+([RFC 7644, Section 3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12)). Note that `status` is a **string**:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "status": "409",
+  "scimType": "uniqueness",
+  "detail": "Could not create user: identity already exists in another scope"
+}
+```
+
+`scimType` and `detail` are present only when applicable. Common error cases:
+
+| Status | `scimType`                       | When it happens                                                                                                                                     |
+| ------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | `invalidSyntax`                  | The request body could not be decoded, or a resource failed validation (for example a missing `userName`, an invalid time zone, or more than one `primary` entry). |
+| `400`  | `invalidValue`                   | A value is malformed, for example a group member `value` that is not a valid UUID, or a member `type` other than `"User"` or `"Group"`.              |
+| `400`  | `invalidFilter`                  | The `filter` is malformed, references a non-indexed attribute, or references an unsupported schema.                                                  |
+| `400`  | `invalidPath`                    | A PATCH `path` is invalid or references an unsupported attribute.                                                                                    |
+| `400`  | `noTarget`                       | A PATCH `remove` (or `replace` with no matching element) has no target path.                                                                         |
+| `400`  | `tooMany`                        | `startIndex` exceeds `5000` or `count` exceeds `1000`.                                                                                               |
+| `400`  | `invalidCursor` / `expiredCursor`| The pagination cursor is invalid or has expired. Restart pagination from the first page.                                                            |
+| `401`  | —                                | The `Authorization` header is missing or does not match the configured secret.                                                                      |
+| `404`  | —                                | The SCIM client, user, group, schema, or resource type does not exist — including when the resource belongs to a different organization.            |
+| `409`  | `uniqueness`                     | A conflicting resource already exists. For users this includes a duplicate `userName`/email and the cross-organization case (see below). For groups this includes a duplicate `externalId`. |
+| `413`  | —                                | The request body exceeds the 16 MiB limit.                                                                                                          |
+| `500`  | —                                | An internal error occurred, for example the data mapping script failed to fetch or evaluate, or a database write failed.                            |
+
+The most common conflict integrators encounter is provisioning a user who already exists in a **different** organization, which
+returns:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "status": "409",
+  "scimType": "uniqueness",
+  "detail": "Could not create user: identity already exists in another scope"
+}
+```
+
+See [How SCIM relates to organizations](../scim#how-scim-relates-to-organizations) for why this happens and how to resolve it.
+
+## Supported features
+
+The server advertises its capabilities through `GET /ServiceProviderConfig`. At a glance:
+
+| Feature                   | Supported | Notes                                                              |
+| ------------------------- | --------- | ------------------------------------------------------------------ |
+| PATCH                     | Yes       | RFC 7644 PatchOp with `add`, `replace`, `remove`.                  |
+| Filtering                 | Yes       | `eq` operator only, on indexed attributes (see [Filtering](#filtering)). |
+| Change password           | Yes       | Through the `password` attribute.                                  |
+| Pagination (offset)       | Yes       | `startIndex` / `count`.                                            |
+| Pagination (cursor)       | Yes       | `cursor` / `nextCursor`, RFC 9865.                                 |
+| Enterprise User extension | Yes       | RFC 7643 §4.3.                                                     |
+| Sorting                   | No        | `sortBy` / `sortOrder` are not supported.                          |
+| ETag / versioning         | No        |                                                                    |
+| Bulk operations           | No        | No `/Bulk` endpoint.                                               |
+| `/Me` endpoint            | No        |                                                                    |

--- a/docs/kratos/manage-identities/scim/api-reference.mdx
+++ b/docs/kratos/manage-identities/scim/api-reference.mdx
@@ -67,9 +67,9 @@ Authentication errors:
 
 :::note
 
-`ServiceProviderConfig` advertises `oauthbearertoken` as the authentication scheme — a bearer token in the `Authorization`
-header. The token is the SCIM client's configured Authorization header secret, which is a static shared secret rather than an
-OAuth-issued token.
+`ServiceProviderConfig` advertises `oauthbearertoken` as the authentication scheme — a bearer token in the `Authorization` header.
+The token is the SCIM client's configured Authorization header secret, which is a static shared secret rather than an OAuth-issued
+token.
 
 :::
 
@@ -484,7 +484,8 @@ in a single request; setting both returns `400`.
 ## Errors
 
 Errors are returned with an appropriate HTTP status code and a SCIM error body
-([RFC 7644, Section 3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12)). Note that as per spec `status` is a **string**:
+([RFC 7644, Section 3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12)). Note that as per spec `status` is a
+**string**:
 
 ```json
 {

--- a/docs/kratos/manage-identities/scim/api-reference.mdx
+++ b/docs/kratos/manage-identities/scim/api-reference.mdx
@@ -134,7 +134,7 @@ The `{id}` is the Ory identity ID (a UUID), returned as `id` when the user is cr
 
 ### Create a user
 
-```http
+```text
 POST /Users
 Content-Type: application/scim+json
 Authorization: Bearer <your-secret>
@@ -162,7 +162,6 @@ On success the server responds with `201 Created` and the full user resource:
   "name": { "givenName": "Barbara", "familyName": "Jensen" },
   "active": true,
   "emails": [{ "value": "bjensen@example.com", "primary": true, "type": "work" }],
-  "groups": [],
   "meta": {
     "resourceType": "User",
     "created": "2026-06-15T10:00:00Z",
@@ -179,7 +178,7 @@ If the user already exists, the create may succeed as an update (auto-linking) o
 
 ### Retrieve a user
 
-```http
+```text
 GET /Users/9f8e7d6c-5b4a-3210-fedc-ba9876543210
 ```
 
@@ -187,7 +186,7 @@ Returns `200 OK` and the user resource shown above.
 
 ### List users
 
-```http
+```text
 GET /Users?startIndex=1&count=20
 ```
 
@@ -208,8 +207,9 @@ for the `filter` query parameter.
 
 ### Replace a user
 
-`PUT /Users/{id}` replaces the user with the supplied representation. Attributes that are not present in the request are reset to
-their default. Use `PATCH` for partial updates.
+`PUT /Users/{id}` replaces the user with the supplied representation, so send the full resource. Attributes you omit are reset to
+their defaults — for example, omitting `active` re-enables the user. The `password` is the exception: it is changed only when you
+include it. Use `PATCH` for partial updates.
 
 ### Update a user (PATCH)
 
@@ -314,7 +314,7 @@ by the URN, and the URN is added to the resource's `schemas` array:
 
 ### Create a group
 
-```http
+```text
 POST /Groups
 Content-Type: application/scim+json
 Authorization: Bearer <your-secret>
@@ -397,7 +397,7 @@ For anything beyond a small first page, use keyset (cursor) pagination as define
 passing `cursor` with an empty value (or a known cursor), then follow `nextCursor` from each response until it is no longer
 returned:
 
-```http
+```text
 GET /Users?count=20&cursor=
 ```
 
@@ -450,7 +450,7 @@ attributes:
 | Users    | `userName`, `externalId`, `employeeNumber`, `groups.value` (a group UUID) |
 | Groups   | `displayName`, `externalId`                                               |
 
-```http
+```text
 GET /Users?filter=userName eq "bjensen@example.com"
 ```
 
@@ -465,8 +465,8 @@ GET /Users?filter=userName eq "bjensen@example.com"
 A user's `groups.value` is a group ID, so you can list the users that belong to a specific group by filtering `/Users` on
 `groups.value` with that group's ID:
 
-```http
-GET /Users?filter=groups.value eq "b3f8…group-uuid"
+```text
+GET /Users?filter=groups.value eq "<group-id>"
 ```
 
 - The filter value must be a valid group UUID; otherwise the request returns `400` with `scimType: invalidFilter` and the detail

--- a/docs/kratos/manage-identities/scim/api-reference.mdx
+++ b/docs/kratos/manage-identities/scim/api-reference.mdx
@@ -134,7 +134,7 @@ The `{id}` is the Ory identity ID (a UUID), returned as `id` when the user is cr
 
 ### Create a user
 
-```text
+```http
 POST /Users
 Content-Type: application/scim+json
 Authorization: Bearer <your-secret>
@@ -178,7 +178,7 @@ If the user already exists, the create may succeed as an update (auto-linking) o
 
 ### Retrieve a user
 
-```text
+```http
 GET /Users/9f8e7d6c-5b4a-3210-fedc-ba9876543210
 ```
 
@@ -186,7 +186,7 @@ Returns `200 OK` and the user resource shown above.
 
 ### List users
 
-```text
+```http
 GET /Users?startIndex=1&count=20
 ```
 
@@ -314,7 +314,7 @@ by the URN, and the URN is added to the resource's `schemas` array:
 
 ### Create a group
 
-```text
+```http
 POST /Groups
 Content-Type: application/scim+json
 Authorization: Bearer <your-secret>
@@ -397,7 +397,7 @@ For anything beyond a small first page, use keyset (cursor) pagination as define
 passing `cursor` with an empty value (or a known cursor), then follow `nextCursor` from each response until it is no longer
 returned:
 
-```text
+```http
 GET /Users?count=20&cursor=
 ```
 
@@ -450,7 +450,7 @@ attributes:
 | Users    | `userName`, `externalId`, `employeeNumber`, `groups.value` (a group UUID) |
 | Groups   | `displayName`, `externalId`                                               |
 
-```text
+```http
 GET /Users?filter=userName eq "bjensen@example.com"
 ```
 
@@ -465,7 +465,7 @@ GET /Users?filter=userName eq "bjensen@example.com"
 A user's `groups.value` is a group ID, so you can list the users that belong to a specific group by filtering `/Users` on
 `groups.value` with that group's ID:
 
-```text
+```http
 GET /Users?filter=groups.value eq "<group-id>"
 ```
 

--- a/docs/kratos/manage-identities/scim/api-reference.mdx
+++ b/docs/kratos/manage-identities/scim/api-reference.mdx
@@ -15,11 +15,10 @@ import Help from '@site/docs/_common/need-help.mdx'
 This page is a reference for the Ory Network SCIM server API. It describes the base URL and authentication, every available
 endpoint with example requests and responses, the supported resource schemas, pagination and filtering, and the error model.
 
-For a conceptual overview, how SCIM relates to organizations, auto-linking, and data mapping, see the
-[SCIM overview](../scim).
+For a conceptual overview, how SCIM relates to organizations, auto-linking, and data mapping, see the [SCIM overview](../scim).
 
-The Ory Network SCIM server implements SCIM 2.0 as defined in [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643)
-(schemas) and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) (protocol), with cursor-based pagination from
+The Ory Network SCIM server implements SCIM 2.0 as defined in [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) (schemas)
+and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) (protocol), with cursor-based pagination from
 [RFC 9865](https://datatracker.ietf.org/doc/html/rfc9865).
 
 ## Base URL
@@ -31,8 +30,7 @@ https://<project-slug>.projects.oryapis.com/scim/<client-id>/v2
 ```
 
 The exact URL is shown in the Ory Console when you create or edit a SCIM client. All endpoint paths below are relative to this
-base URL — for example, `POST /Users` means
-`POST https://<project-slug>.projects.oryapis.com/scim/<client-id>/v2/Users`.
+base URL — for example, `POST /Users` means `POST https://<project-slug>.projects.oryapis.com/scim/<client-id>/v2/Users`.
 
 The server returns `Content-Type: application/scim+json` on every response. Send the same content type on requests that have a
 body.
@@ -46,8 +44,8 @@ client. The server compares the header against the configured secret using a con
 Authorization: Bearer <your-secret>
 ```
 
-When comparing, the server trims surrounding whitespace and strips a single leading, case-insensitive `Bearer ` prefix. This
-means that if your configured secret is `s3cr3t`, both of the following are accepted:
+When comparing, the server trims surrounding whitespace and strips a single leading, case-insensitive `Bearer` prefix. This means
+that if your configured secret is `s3cr3t`, both of the following are accepted:
 
 - `Authorization: Bearer s3cr3t`
 - `Authorization: s3cr3t`
@@ -55,22 +53,23 @@ means that if your configured secret is `s3cr3t`, both of the following are acce
 :::info
 
 Some identity providers (for example Microsoft Entra) ask you to enter the token **without** the `Bearer` prefix and add it
-themselves. Because only one `Bearer ` prefix is stripped, configure the secret without a `Bearer ` prefix to avoid
+themselves. Because only one `Bearer` prefix is stripped, configure the secret without a `Bearer` prefix to avoid
 double-prefixing. See the [provider guides](../scim#use-the-scim-client) for provider-specific instructions.
 
 :::
 
 Authentication errors:
 
-| Condition                       | Status | `detail`                        |
-| ------------------------------- | ------ | ------------------------------- |
-| No `Authorization` header       | `401`  | `no authorization header found` |
-| Header does not match the secret| `401`  | `invalid authorization header`  |
+| Condition                        | Status | `detail`                        |
+| -------------------------------- | ------ | ------------------------------- |
+| No `Authorization` header        | `401`  | `no authorization header found` |
+| Header does not match the secret | `401`  | `invalid authorization header`  |
 
 :::note
 
-`ServiceProviderConfig` advertises `httpbasic` as the authentication scheme for SCIM-discovery compatibility, but
-authentication is performed against the shared secret in the `Authorization` header as described above.
+`ServiceProviderConfig` advertises `oauthbearertoken` as the authentication scheme — a bearer token in the `Authorization`
+header. The token is the SCIM client's configured Authorization header secret, which is a static shared secret rather than an
+OAuth-issued token.
 
 :::
 
@@ -79,13 +78,13 @@ authentication is performed against the shared secret in the `Authorization` hea
 These read-only endpoints let SCIM clients and conformance tools discover the server's capabilities. They do not require a
 resource ID.
 
-| Method | Path                          | Description                                              |
-| ------ | ----------------------------- | -------------------------------------------------------- |
-| `GET`  | `/ServiceProviderConfig`      | Server capabilities (patch, filter, pagination, auth)    |
-| `GET`  | `/ResourceTypes`              | List of supported resource types (`User`, `Group`)       |
-| `GET`  | `/ResourceTypes/{id}`         | A single resource type, where `id` is `User` or `Group`  |
-| `GET`  | `/Schemas`                    | List of supported schemas (User, Group, Enterprise User) |
-| `GET`  | `/Schemas/{id}`               | A single schema, where `id` is the schema URN            |
+| Method | Path                     | Description                                              |
+| ------ | ------------------------ | -------------------------------------------------------- |
+| `GET`  | `/ServiceProviderConfig` | Server capabilities (patch, filter, pagination, auth)    |
+| `GET`  | `/ResourceTypes`         | List of supported resource types (`User`, `Group`)       |
+| `GET`  | `/ResourceTypes/{id}`    | A single resource type, where `id` is `User` or `Group`  |
+| `GET`  | `/Schemas`               | List of supported schemas (User, Group, Enterprise User) |
+| `GET`  | `/Schemas/{id}`          | A single schema, where `id` is the schema URN            |
 
 ### GET /ServiceProviderConfig
 
@@ -109,10 +108,10 @@ resource ID.
   },
   "authenticationSchemes": [
     {
-      "type": "httpbasic",
-      "name": "HTTP Basic Authentication",
-      "description": "Authentication through a shared secret in the Authorization HTTP header.",
-      "specUri": "https://datatracker.ietf.org/doc/rfc7617/",
+      "type": "oauthbearertoken",
+      "name": "OAuth Bearer Token",
+      "description": "Authentication using a bearer token in the Authorization HTTP header.",
+      "specUri": "https://datatracker.ietf.org/doc/html/rfc6750",
       "documentationUri": "https://www.ory.com/docs/kratos/manage-identities/scim#configure-a-scim-client"
     }
   ],
@@ -122,14 +121,14 @@ resource ID.
 
 ## Users
 
-| Method   | Path           | Description                          | Success status |
-| -------- | -------------- | ------------------------------------ | -------------- |
-| `GET`    | `/Users`       | List or search users                 | `200`          |
-| `POST`   | `/Users`       | Create a user                        | `201`          |
-| `GET`    | `/Users/{id}`  | Retrieve a user by ID                | `200`          |
-| `PUT`    | `/Users/{id}`  | Replace a user (full update)         | `200`          |
-| `PATCH`  | `/Users/{id}`  | Partially update a user (PatchOp)    | `200`          |
-| `DELETE` | `/Users/{id}`  | Delete a user (deletes the identity) | `204`          |
+| Method   | Path          | Description                          | Success status |
+| -------- | ------------- | ------------------------------------ | -------------- |
+| `GET`    | `/Users`      | List or search users                 | `200`          |
+| `POST`   | `/Users`      | Create a user                        | `201`          |
+| `GET`    | `/Users/{id}` | Retrieve a user by ID                | `200`          |
+| `PUT`    | `/Users/{id}` | Replace a user (full update)         | `200`          |
+| `PATCH`  | `/Users/{id}` | Partially update a user (PatchOp)    | `200`          |
+| `DELETE` | `/Users/{id}` | Delete a user (deletes the identity) | `204`          |
 
 The `{id}` is the Ory identity ID (a UUID), returned as `id` when the user is created.
 
@@ -172,9 +171,8 @@ On success the server responds with `201 Created` and the full user resource:
 }
 ```
 
-How the incoming attributes are applied to the Ory identity is controlled by the client's
-[data mapping](../scim#data-mapping). The `password` attribute, if present, is stored as a password credential and is never
-returned in any response.
+How the incoming attributes are applied to the Ory identity is controlled by the client's [data mapping](../scim#data-mapping).
+The `password` attribute, if present, is stored as a password credential and is never returned in any response.
 
 If the user already exists, the create may succeed as an update (auto-linking) or fail with a `409` conflict. See
 [How SCIM relates to organizations](../scim#how-scim-relates-to-organizations) and [Errors](#errors).
@@ -193,8 +191,8 @@ Returns `200 OK` and the user resource shown above.
 GET /Users?startIndex=1&count=20
 ```
 
-Returns a `ListResponse` envelope. See [Pagination](#pagination) for the offset and cursor variants and
-[Filtering](#filtering) for the `filter` query parameter.
+Returns a `ListResponse` envelope. See [Pagination](#pagination) for the offset and cursor variants and [Filtering](#filtering)
+for the `filter` query parameter.
 
 ```json
 {
@@ -244,31 +242,31 @@ deleting it, set `active` to `false` instead. See [Deprovisioning identities](..
 Ory Network supports the standard SCIM user resource schema as defined in
 [RFC 7643, Section 4.1](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1). The following attributes are supported:
 
-| Name                | Type   | Remarks                                                                                                                                                                                               |
-| ------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                | UUID   | Read-only, this is the identity ID.                                                                                                                                                                   |
-| `externalId`        | string | Optional, an ID set by the SCIM client. Filterable (case-sensitive).                                                                                                                                  |
-| `userName`          | string | Required, unique identifier for the user. Typically used as the login identifier. Filterable.                                                                                                         |
-| `name`              | object | Contains sub-attributes `formatted`, `familyName`, `givenName`, `middleName`, `honorificPrefix`, and `honorificSuffix`.                                                                               |
-| `displayName`       | string |                                                                                                                                                                                                       |
-| `nickName`          | string |                                                                                                                                                                                                       |
-| `profileUrl`        | string |                                                                                                                                                                                                       |
-| `title`             | string |                                                                                                                                                                                                       |
-| `userType`          | string |                                                                                                                                                                                                       |
-| `preferredLanguage` | string |                                                                                                                                                                                                       |
-| `locale`            | string |                                                                                                                                                                                                       |
-| `timezone`          | string | If set, must be a valid time zone.                                                                                                                                                                    |
-| `active`            | bool   | Whether the user can log in. **If omitted on create or replace, defaults to `true`.** Set to `false` to deactivate the user; deactivated users cannot log in.                                          |
-| `password`          | string | If set, the user can log in with this password. The password is never returned in any SCIM response.                                                                                                  |
-| `emails`            | array  | List of email addresses. Each email can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` email can be set.                           |
-| `phoneNumbers`      | array  | List of phone numbers. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                     |
-| `ims`               | array  | List of instant messaging accounts. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                        |
-| `photos`            | array  | List of photos. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                            |
-| `addresses`         | array  | List of addresses. Each address can have `formatted`, `streetAddress`, `locality`, `region`, `postalCode`, `country`, and `type`.                                                                     |
-| `groups`            | array  | Read-only, a list of groups the user is a direct member of. Each entry has `value`, `display`, and `type`. To modify, set the `members` property on the `Groups` resource.                            |
-| `entitlements`      | array  | List of entitlements. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                      |
-| `roles`             | array  | List of roles. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                             |
-| `x509Certificates`  | array  | List of X.509 certificates. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                                |
+| Name                | Type   | Remarks                                                                                                                                                                     |
+| ------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                | UUID   | Read-only, this is the identity ID.                                                                                                                                         |
+| `externalId`        | string | Optional, an ID set by the SCIM client. Filterable (case-sensitive).                                                                                                        |
+| `userName`          | string | Required, unique identifier for the user. Typically used as the login identifier. Filterable.                                                                               |
+| `name`              | object | Contains sub-attributes `formatted`, `familyName`, `givenName`, `middleName`, `honorificPrefix`, and `honorificSuffix`.                                                     |
+| `displayName`       | string |                                                                                                                                                                             |
+| `nickName`          | string |                                                                                                                                                                             |
+| `profileUrl`        | string |                                                                                                                                                                             |
+| `title`             | string |                                                                                                                                                                             |
+| `userType`          | string |                                                                                                                                                                             |
+| `preferredLanguage` | string |                                                                                                                                                                             |
+| `locale`            | string |                                                                                                                                                                             |
+| `timezone`          | string | If set, must be a valid time zone.                                                                                                                                          |
+| `active`            | bool   | Whether the user can log in. **If omitted on create or replace, defaults to `true`.** Set to `false` to deactivate the user; deactivated users cannot log in.               |
+| `password`          | string | If set, the user can log in with this password. The password is never returned in any SCIM response.                                                                        |
+| `emails`            | array  | List of email addresses. Each email can have a `value` (string), `display` (string), `primary` (boolean), and `type` (string). At most one `primary=true` email can be set. |
+| `phoneNumbers`      | array  | List of phone numbers. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                          |
+| `ims`               | array  | List of instant messaging accounts. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                             |
+| `photos`            | array  | List of photos. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                 |
+| `addresses`         | array  | List of addresses. Each address can have `formatted`, `streetAddress`, `locality`, `region`, `postalCode`, `country`, and `type`.                                           |
+| `groups`            | array  | Read-only, a list of groups the user is a direct member of. Each entry has `value`, `display`, and `type`. To modify, set the `members` property on the `Groups` resource.  |
+| `entitlements`      | array  | List of entitlements. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                           |
+| `roles`             | array  | List of roles. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                                  |
+| `x509Certificates`  | array  | List of X.509 certificates. Each entry can have `value`, `display`, `primary`, and `type`. At most one `primary=true` entry can be set.                                     |
 
 ### Enterprise User extension
 
@@ -279,10 +277,7 @@ by the URN, and the URN is added to the resource's `schemas` array:
 
 ```json
 {
-  "schemas": [
-    "urn:ietf:params:scim:schemas:core:2.0:User",
-    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-  ],
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
   "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210",
   "userName": "bjensen@example.com",
   "active": true,
@@ -297,25 +292,25 @@ by the URN, and the URN is added to the resource's `schemas` array:
 }
 ```
 
-| Name             | Type   | Remarks                                                                                                                  |
-| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `employeeNumber` | string | Filterable.                                                                                                              |
-| `costCenter`     | string |                                                                                                                          |
-| `organization`   | string | A free-form string attribute; unrelated to the Ory organization the SCIM client is bound to.                            |
-| `division`       | string |                                                                                                                          |
-| `department`     | string |                                                                                                                          |
+| Name             | Type   | Remarks                                                                                                                                            |
+| ---------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `employeeNumber` | string | Filterable.                                                                                                                                        |
+| `costCenter`     | string |                                                                                                                                                    |
+| `organization`   | string | A free-form string attribute; unrelated to the Ory organization the SCIM client is bound to.                                                       |
+| `division`       | string |                                                                                                                                                    |
+| `department`     | string |                                                                                                                                                    |
 | `manager`        | object | `value` is the manager's identity ID. `manager.displayName` is read-only and is only resolved if the manager identity is in the same organization. |
 
 ## Groups
 
-| Method   | Path            | Description                       | Success status |
-| -------- | --------------- | --------------------------------- | -------------- |
-| `GET`    | `/Groups`       | List or search groups             | `200`          |
-| `POST`   | `/Groups`       | Create a group                    | `201`          |
-| `GET`    | `/Groups/{id}`  | Retrieve a group by ID            | `200`          |
-| `PUT`    | `/Groups/{id}`  | Replace a group (full update)     | `200`          |
-| `PATCH`  | `/Groups/{id}`  | Partially update a group (PatchOp)| `200`          |
-| `DELETE` | `/Groups/{id}`  | Delete a group                    | `204`          |
+| Method   | Path           | Description                        | Success status |
+| -------- | -------------- | ---------------------------------- | -------------- |
+| `GET`    | `/Groups`      | List or search groups              | `200`          |
+| `POST`   | `/Groups`      | Create a group                     | `201`          |
+| `GET`    | `/Groups/{id}` | Retrieve a group by ID             | `200`          |
+| `PUT`    | `/Groups/{id}` | Replace a group (full update)      | `200`          |
+| `PATCH`  | `/Groups/{id}` | Partially update a group (PatchOp) | `200`          |
+| `DELETE` | `/Groups/{id}` | Delete a group                     | `204`          |
 
 ### Create a group
 
@@ -367,53 +362,40 @@ Group memberships are managed through the `members` attribute on the `Groups` re
 
 The `groups` attribute on a user resource reflects only the user's **direct** memberships and is read-only.
 
-To change memberships incrementally, use `PATCH /Groups/{id}` with `add` and `remove` operations targeting the `members` path.
-A `remove` without a `path` returns `400 noTarget` rather than removing all members.
+To change memberships incrementally, use `PATCH /Groups/{id}` with `add` and `remove` operations targeting the `members` path. A
+`remove` without a `path` returns `400 noTarget` rather than removing all members.
 
 ### Group resource schema
 
 Ory Network supports the standard SCIM group resource schema as defined in
 [RFC 7643, Section 4.2](https://datatracker.ietf.org/doc/html/rfc7643#section-4.2):
 
-| Name          | Type   | Remarks                                                                                                                       |
-| ------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | UUID   | Read-only, this is the group ID.                                                                                              |
-| `externalId`  | string | Optional, an ID set by the SCIM client. If set, it must be unique within the organization. Filterable.                        |
-| `displayName` | string | Required, the name of the group. Filterable.                                                                                  |
-| `members`     | array  | List of members. Each member has `value`, `display` (read-only), and `type` (`"User"` or `"Group"`). See above.               |
+| Name          | Type   | Remarks                                                                                                         |
+| ------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| `id`          | UUID   | Read-only, this is the group ID.                                                                                |
+| `externalId`  | string | Optional, an ID set by the SCIM client. If set, it must be unique within the organization. Filterable.          |
+| `displayName` | string | Required, the name of the group. Filterable.                                                                    |
+| `members`     | array  | List of members. Each member has `value`, `display` (read-only), and `type` (`"User"` or `"Group"`). See above. |
 
 ## Pagination
 
-The list endpoints (`GET /Users` and `GET /Groups`) support two mutually exclusive pagination methods. Offset-based pagination is
-the default; cursor-based pagination is used when a `cursor` query parameter is present.
+The list endpoints (`GET /Users` and `GET /Groups`) support two mutually exclusive pagination methods: cursor-based and
+offset-based. Offset-based is used by default; cursor-based is used when a `cursor` query parameter is present.
 
-### Offset-based pagination (default)
+:::tip
 
-Uses the standard SCIM `startIndex` (1-based) and `count` query parameters.
+**Prefer cursor-based pagination.** It is significantly faster on large directories and has no upper bound, whereas offset-based
+pagination caps `startIndex` at 5000 and `count` at 1000. Use offset-based pagination only for small result sets or a quick first
+page.
 
-| Parameter    | Default | Limit               |
-| ------------ | ------- | ------------------- |
-| `startIndex` | `1`     | must be ≤ `5000`    |
-| `count`      | `100`   | must be ≤ `1000`    |
+:::
 
-`startIndex` or `count` above the limit returns `400` with `scimType: tooMany`. A `count` of `0` returns only `totalResults`
-with no `Resources` array. Offset responses always include `totalResults` (including `0`):
+### Cursor-based pagination (recommended)
 
-```json
-{
-  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-  "totalResults": 42,
-  "startIndex": 1,
-  "itemsPerPage": 20,
-  "Resources": [ ]
-}
-```
-
-### Cursor-based pagination
-
-For large result sets, use keyset (cursor) pagination as defined in
-[RFC 9865](https://datatracker.ietf.org/doc/html/rfc9865). Start by passing `cursor` with an empty value (or a known cursor),
-then follow `nextCursor` from each response until it is no longer returned:
+For anything beyond a small first page, use keyset (cursor) pagination as defined in
+[RFC 9865](https://datatracker.ietf.org/doc/html/rfc9865). It is faster on large directories and has no upper bound. Start by
+passing `cursor` with an empty value (or a known cursor), then follow `nextCursor` from each response until it is no longer
+returned:
 
 ```http
 GET /Users?count=20&cursor=
@@ -423,8 +405,8 @@ GET /Users?count=20&cursor=
 {
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
   "itemsPerPage": 20,
-  "nextCursor": "<opaque-encrypted-cursor>",
-  "Resources": [ ]
+  "nextCursor": "<opaque-cursor>",
+  "Resources": []
 }
 ```
 
@@ -435,15 +417,38 @@ GET /Users?count=20&cursor=
 - `nextCursor` is omitted on the last page.
 - `totalResults` is **not** returned on cursor pages.
 
+### Offset-based pagination (default)
+
+Offset-based pagination uses the standard SCIM `startIndex` (1-based) and `count` query parameters. It is the default when no
+`cursor` parameter is present, but it is capped — use cursor-based pagination for large directories.
+
+| Parameter    | Default | Limit            |
+| ------------ | ------- | ---------------- |
+| `startIndex` | `1`     | must be ≤ `5000` |
+| `count`      | `100`   | must be ≤ `1000` |
+
+`startIndex` or `count` above the limit returns `400` with `scimType: tooMany`. A `count` of `0` returns only `totalResults` with
+no `Resources` array. Offset responses always include `totalResults` (including `0`):
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 42,
+  "startIndex": 1,
+  "itemsPerPage": 20,
+  "Resources": []
+}
+```
+
 ## Filtering
 
 The list endpoints accept a `filter` query parameter. Only the `eq` (equals) operator is supported, and only on indexed
 attributes:
 
-| Resource | Filterable attributes                                              |
-| -------- | ------------------------------------------------------------------ |
+| Resource | Filterable attributes                                                     |
+| -------- | ------------------------------------------------------------------------- |
 | Users    | `userName`, `externalId`, `employeeNumber`, `groups.value` (a group UUID) |
-| Groups   | `displayName`, `externalId`                                        |
+| Groups   | `displayName`, `externalId`                                               |
 
 ```http
 GET /Users?filter=userName eq "bjensen@example.com"
@@ -455,6 +460,22 @@ GET /Users?filter=userName eq "bjensen@example.com"
 - A `filter` may reference a supported schema URN prefix; references to unsupported schemas return `400`.
 - The `filter` query string is limited to 1024 bytes.
 
+### Filtering users by group
+
+A user's `groups.value` is a group ID, so you can list the users that belong to a specific group by filtering `/Users` on
+`groups.value` with that group's ID:
+
+```http
+GET /Users?filter=groups.value eq "b3f8…group-uuid"
+```
+
+- The filter value must be a valid group UUID; otherwise the request returns `400` with `scimType: invalidFilter` and the detail
+  `The filter value for groups.value must be a valid UUID.`
+- Only **direct** members are matched. A user who belongs to the group only through a nested sub-group is not returned — query
+  those sub-groups separately.
+- This is the inverse of reading a group's `members` list (`GET /Groups/{id}`). It is the efficient way to enumerate a group's
+  users, and it pairs well with [cursor-based pagination](#cursor-based-pagination-recommended) for large groups.
+
 ## Attribute selection
 
 The `attributes` and `excludedAttributes` query parameters control which attributes are returned. Only one of the two may be set
@@ -463,7 +484,7 @@ in a single request; setting both returns `400`.
 ## Errors
 
 Errors are returned with an appropriate HTTP status code and a SCIM error body
-([RFC 7644, Section 3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12)). Note that `status` is a **string**:
+([RFC 7644, Section 3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12)). Note that as per spec `status` is a **string**:
 
 ```json
 {
@@ -476,20 +497,20 @@ Errors are returned with an appropriate HTTP status code and a SCIM error body
 
 `scimType` and `detail` are present only when applicable. Common error cases:
 
-| Status | `scimType`                       | When it happens                                                                                                                                     |
-| ------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `400`  | `invalidSyntax`                  | The request body could not be decoded, or a resource failed validation (for example a missing `userName`, an invalid time zone, or more than one `primary` entry). |
-| `400`  | `invalidValue`                   | A value is malformed, for example a group member `value` that is not a valid UUID, or a member `type` other than `"User"` or `"Group"`.              |
-| `400`  | `invalidFilter`                  | The `filter` is malformed, references a non-indexed attribute, or references an unsupported schema.                                                  |
-| `400`  | `invalidPath`                    | A PATCH `path` is invalid or references an unsupported attribute.                                                                                    |
-| `400`  | `noTarget`                       | A PATCH `remove` (or `replace` with no matching element) has no target path.                                                                         |
-| `400`  | `tooMany`                        | `startIndex` exceeds `5000` or `count` exceeds `1000`.                                                                                               |
-| `400`  | `invalidCursor` / `expiredCursor`| The pagination cursor is invalid or has expired. Restart pagination from the first page.                                                            |
-| `401`  | —                                | The `Authorization` header is missing or does not match the configured secret.                                                                      |
-| `404`  | —                                | The SCIM client, user, group, schema, or resource type does not exist — including when the resource belongs to a different organization.            |
-| `409`  | `uniqueness`                     | A conflicting resource already exists. For users this includes a duplicate `userName`/email and the cross-organization case (see below). For groups this includes a duplicate `externalId`. |
-| `413`  | —                                | The request body exceeds the 16 MiB limit.                                                                                                          |
-| `500`  | —                                | An internal error occurred, for example the data mapping script failed to fetch or evaluate, or a database write failed.                            |
+| Status | `scimType`                        | When it happens                                                                                                                                                                             |
+| ------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | `invalidSyntax`                   | The request body could not be decoded, or a resource failed validation (for example a missing `userName`, an invalid time zone, or more than one `primary` entry).                          |
+| `400`  | `invalidValue`                    | A value is malformed, for example a group member `value` that is not a valid UUID, or a member `type` other than `"User"` or `"Group"`.                                                     |
+| `400`  | `invalidFilter`                   | The `filter` is malformed, references a non-indexed attribute, or references an unsupported schema.                                                                                         |
+| `400`  | `invalidPath`                     | A PATCH `path` is invalid or references an unsupported attribute.                                                                                                                           |
+| `400`  | `noTarget`                        | A PATCH `remove` (or `replace` with no matching element) has no target path.                                                                                                                |
+| `400`  | `tooMany`                         | `startIndex` exceeds `5000` or `count` exceeds `1000`.                                                                                                                                      |
+| `400`  | `invalidCursor` / `expiredCursor` | The pagination cursor is invalid or has expired. Restart pagination from the first page.                                                                                                    |
+| `401`  | —                                 | The `Authorization` header is missing or does not match the configured secret.                                                                                                              |
+| `404`  | —                                 | The SCIM client, user, group, schema, or resource type does not exist — including when the resource belongs to a different organization.                                                    |
+| `409`  | `uniqueness`                      | A conflicting resource already exists. For users this includes a duplicate `userName`/email and the cross-organization case (see below). For groups this includes a duplicate `externalId`. |
+| `413`  | —                                 | The request body exceeds the 16 MiB limit.                                                                                                                                                  |
+| `500`  | —                                 | An internal error occurred, for example the data mapping script failed to fetch or evaluate, or a database write failed.                                                                    |
 
 The most common conflict integrators encounter is provisioning a user who already exists in a **different** organization, which
 returns:
@@ -509,15 +530,15 @@ See [How SCIM relates to organizations](../scim#how-scim-relates-to-organization
 
 The server advertises its capabilities through `GET /ServiceProviderConfig`. At a glance:
 
-| Feature                   | Supported | Notes                                                              |
-| ------------------------- | --------- | ------------------------------------------------------------------ |
-| PATCH                     | Yes       | RFC 7644 PatchOp with `add`, `replace`, `remove`.                  |
+| Feature                   | Supported | Notes                                                                    |
+| ------------------------- | --------- | ------------------------------------------------------------------------ |
+| PATCH                     | Yes       | RFC 7644 PatchOp with `add`, `replace`, `remove`.                        |
 | Filtering                 | Yes       | `eq` operator only, on indexed attributes (see [Filtering](#filtering)). |
-| Change password           | Yes       | Through the `password` attribute.                                  |
-| Pagination (offset)       | Yes       | `startIndex` / `count`.                                            |
-| Pagination (cursor)       | Yes       | `cursor` / `nextCursor`, RFC 9865.                                 |
-| Enterprise User extension | Yes       | RFC 7643 §4.3.                                                     |
-| Sorting                   | No        | `sortBy` / `sortOrder` are not supported.                          |
-| ETag / versioning         | No        |                                                                    |
-| Bulk operations           | No        | No `/Bulk` endpoint.                                               |
-| `/Me` endpoint            | No        |                                                                    |
+| Change password           | Yes       | Through the `password` attribute.                                        |
+| Pagination (offset)       | Yes       | `startIndex` / `count`.                                                  |
+| Pagination (cursor)       | Yes       | `cursor` / `nextCursor`, RFC 9865.                                       |
+| Enterprise User extension | Yes       | RFC 7643 §4.3.                                                           |
+| Sorting                   | No        | `sortBy` / `sortOrder` are not supported.                                |
+| ETag / versioning         | No        |                                                                          |
+| Bulk operations           | No        | No `/Bulk` endpoint.                                                     |
+| `/Me` endpoint            | No        |                                                                          |

--- a/docs/kratos/organizations/organizations.mdx
+++ b/docs/kratos/organizations/organizations.mdx
@@ -261,10 +261,9 @@ your system but need the identity to be created in Ory Network first, before the
 To achieve this, set the `organization_id` property to the ID of the created organization in the identity, either when creating
 the identity, or by updating the identity's data using the Ory APIs.
 
-To automate provisioning from an external identity provider instead, configure a
-[SCIM client](../manage-identities/50_scim.mdx) for the organization. The SCIM server creates and updates identities in the
-organization automatically. Because an identity can belong to only one organization, provisioning a user that already exists in a
-different organization fails with a conflict — see
+To automate provisioning from an external identity provider instead, configure a [SCIM client](../manage-identities/50_scim.mdx)
+for the organization. The SCIM server creates and updates identities in the organization automatically. Because an identity can
+belong to only one organization, provisioning a user that already exists in a different organization fails with a conflict — see
 [How SCIM relates to organizations](../manage-identities/50_scim.mdx#how-scim-relates-to-organizations) for the full behavior and
 how to resolve it.
 

--- a/docs/kratos/organizations/organizations.mdx
+++ b/docs/kratos/organizations/organizations.mdx
@@ -261,6 +261,13 @@ your system but need the identity to be created in Ory Network first, before the
 To achieve this, set the `organization_id` property to the ID of the created organization in the identity, either when creating
 the identity, or by updating the identity's data using the Ory APIs.
 
+To automate provisioning from an external identity provider instead, configure a
+[SCIM client](../manage-identities/50_scim.mdx) for the organization. The SCIM server creates and updates identities in the
+organization automatically. Because an identity can belong to only one organization, provisioning a user that already exists in a
+different organization fails with a conflict — see
+[How SCIM relates to organizations](../manage-identities/50_scim.mdx#how-scim-relates-to-organizations) for the full behavior and
+how to resolve it.
+
 ## Bind an identity to an organization through the settings flow
 
 A signed-in user can join an organization by linking one of its SSO connections through the

--- a/docs/kratos/reference/jsonnet.mdx
+++ b/docs/kratos/reference/jsonnet.mdx
@@ -164,6 +164,9 @@ local identity = std.extVar('identity');
     metadata_public: std.get(identity, 'metadata_public', {}) + {
       // Add or override only what SCIM should manage here.
     },
+    metadata_admin: std.get(identity, 'metadata_admin', {}) + {
+      // Add or override only what SCIM should manage here.
+    },
   },
 }
 ```

--- a/docs/kratos/reference/jsonnet.mdx
+++ b/docs/kratos/reference/jsonnet.mdx
@@ -27,8 +27,8 @@ The input for Jsonnet is typically provided as an external variable using `std.e
 
 - For OpenID Connect (OIDC), the input is available in `std.extVar('claims')`.
 - For SCIM, the input is available in `std.extVar('scim')`. SCIM additionally provides the existing identity (if one exists) in
-  `std.extVar('identity')`, which exposes `traits`, `metadata_public`, and `metadata_admin` so a mapper can preserve or merge
-  data that SCIM does not manage. See [SCIM data mapping](../manage-identities/scim#data-mapping).
+  `std.extVar('identity')`, which exposes `traits`, `metadata_public`, and `metadata_admin` so a mapper can preserve or merge data
+  that SCIM does not manage. See [SCIM data mapping](../manage-identities/scim#data-mapping).
 
 The specific structure of the input object depends on the data provided by the OIDC claims or SCIM payload.
 

--- a/docs/kratos/reference/jsonnet.mdx
+++ b/docs/kratos/reference/jsonnet.mdx
@@ -26,7 +26,9 @@ sources.
 The input for Jsonnet is typically provided as an external variable using `std.extVar`. For example:
 
 - For OpenID Connect (OIDC), the input is available in `std.extVar('claims')`.
-- For SCIM, the input is available in `std.extVar('scim')`.
+- For SCIM, the input is available in `std.extVar('scim')`. SCIM additionally provides the existing identity (if one exists) in
+  `std.extVar('identity')`, which exposes `traits`, `metadata_public`, and `metadata_admin` so a mapper can preserve or merge
+  data that SCIM does not manage. See [SCIM data mapping](../manage-identities/scim#data-mapping).
 
 The specific structure of the input object depends on the data provided by the OIDC claims or SCIM payload.
 
@@ -138,3 +140,32 @@ else
     },
   }
 ```
+
+### Mapping SCIM data
+
+For SCIM, the input is the SCIM user payload in `std.extVar('scim')`, and the existing identity (if any) is in
+`std.extVar('identity')`. Because the mapping uses full-replace semantics, merge the existing `metadata_public` and
+`metadata_admin` back in so that data managed by other sources (such as OIDC or SAML SSO) is not overwritten on each sync:
+
+```jsonnet
+local scim = std.extVar('scim');
+local identity = std.extVar('identity');
+
+{
+  identity: {
+    traits: {
+      email: scim.userName,
+      [if "name" in scim then "name" else null]: {
+        first: std.get(scim.name, 'givenName', ''),
+        last: std.get(scim.name, 'familyName', ''),
+      },
+    },
+    // Preserve metadata SCIM does not manage, then override only what SCIM should manage.
+    metadata_public: std.get(identity, 'metadata_public', {}) + {
+      // Add or override only what SCIM should manage here.
+    },
+  },
+}
+```
+
+See [SCIM data mapping](../manage-identities/scim#data-mapping) for more details.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -50,6 +50,7 @@ const config: Config = {
         "yaml",
         "csharp",
         "diff",
+        "http",
       ],
       magicComments: [
         {

--- a/sidebars-network.ts
+++ b/sidebars-network.ts
@@ -164,6 +164,7 @@ const networkSidebar = [
                       id: "kratos/manage-identities/scim",
                     },
                     items: [
+                      "kratos/manage-identities/scim/api-reference",
                       "kratos/manage-identities/scim/ms-entra",
                       "kratos/manage-identities/scim/okta",
                       "kratos/manage-identities/scim/google-workspace",


### PR DESCRIPTION
## Summary

Brings the SCIM documentation in line with the recent SCIM improvements in Ory Kratos (general-purpose, enterprise-ready SCIM), and fills the integrator-facing gaps.

- **New SCIM API reference page** (`docs/kratos/manage-identities/scim/api-reference.mdx`): base URL format, authentication (incl. the single-`Bearer`-prefix handling), service-discovery endpoints (`ServiceProviderConfig`, `ResourceTypes`, `Schemas`), full Users/Groups CRUD with happy-path request/response shapes, the User/Group/Enterprise-extension schemas, offset **and** cursor (RFC 9865) pagination, filtering, a SCIM error model + common-error catalogue, and a supported-features matrix.
- **Expanded SCIM overview** (`50_scim.mdx`) into a concept + setup hub: how SCIM relates to organizations (one-org-per-identity, the provisioning matrix), **auto-linking** (matching precedence + verified-domain adoption), **cross-organization conflicts** (the `409 uniqueness` case + resolution), expanded **data mapping** (the `identity` extVar, full-replace semantics, and the relationship to the OIDC/SAML Jsonnet mapper), and **deprovisioning** (`active:false` vs. hard delete).
- **Corrected the Events section** against the implementation: real event names (`SCIMGroupCreated/Updated/Deleted`), the member-event nuance, the previously-undocumented `SCIMProvisioningError` event, and accurate attribute keys (`SCIMClient`, group/error attributes).
- **Jsonnet reference**: documented the SCIM `identity` extVar and added a working SCIM mapping example.
- **Organizations page**: cross-linked to the SCIM org/conflict behavior.
- Wired the API reference page into the network sidebar.

Also fixed three things that were outright incorrect in the live docs: the `active` default (now defaults to `true`), the broken `identity`-merge mapping example, and the misleading "set the base URL" phrasing.

## Test Plan

- [x] `npm install && npx docusaurus build` succeeds
- [x] No broken-link/anchor warnings reference the SCIM pages or their new anchors
- [ ] Visual review of the rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an SCIM API reference entry to the documentation sidebar to make SCIM integration docs easier to find.
* **Documentation**
  * Expanded documentation syntax highlighting to include the `http` language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->