### PR TITLE
docs: document omit_assertion_audience for the JWT bearer grant

### DIFF
--- a/docs/hydra/guides/jwt.mdx
+++ b/docs/hydra/guides/jwt.mdx
@@ -185,6 +185,24 @@ ory patch oauth2-config \
   --replace "/oauth2/grant/jwt/max_ttl=1h"
 ```
 
+### Copying the assertion audience into the access token
+
+By default, Ory copies the `aud` (audience) values from the assertion JWT into the access token it issues. The audience of the
+resulting access token then includes every value from the assertion's `aud` claim, including the OAuth2 token URL.
+
+To stop the assertion's audience from being granted to the access token, set `copy_assertion_audience` to `false`. Ory then issues
+the access token without the audience values from the assertion:
+
+```yaml title="hydra.yml"
+oauth2:
+  grant:
+    jwt:
+      copy_assertion_audience: false
+```
+
+The setting defaults to `true`, which preserves the previous behavior. It's available in self-hosted Ory Hydra (open source) and
+Ory Enterprise License deployments.
+
 ## JWTs for client authentication
 
 Ory provides support for OAuth 2.0 Client Authentication with RSA and ECDSA private/public key pairs and supports signing

--- a/docs/hydra/guides/jwt.mdx
+++ b/docs/hydra/guides/jwt.mdx
@@ -185,23 +185,32 @@ ory patch oauth2-config \
   --replace "/oauth2/grant/jwt/max_ttl=1h"
 ```
 
-### Copying the assertion audience into the access token
+### Assertion audience in the access token
 
-By default, Ory copies the `aud` (audience) values from the assertion JWT into the access token it issues. The audience of the
-resulting access token then includes every value from the assertion's `aud` claim, including the OAuth2 token URL.
+Per [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523), the assertion's `aud` (audience) claim identifies the authorization server
+as the intended recipient of the JWT. It does not define the audience of the issued access token. By default, Ory therefore does
+**not** copy the assertion's `aud` values into the access token.
 
-To stop the assertion's audience from being granted to the access token, set `copy_assertion_audience` to `false`. Ory then issues
-the access token without the audience values from the assertion:
+The `omit_assertion_audience` setting controls this behavior:
 
 ```yaml title="hydra.yml"
 oauth2:
   grant:
     jwt:
-      copy_assertion_audience: false
+      # true (default): the assertion audience is omitted from the access token.
+      # false: the assertion audience is copied into the access token (legacy behavior).
+      omit_assertion_audience: true
 ```
 
-The setting defaults to `true`, which preserves the previous behavior. It's available in self-hosted Ory Hydra (open source) and
-Ory Enterprise License deployments.
+Set it to `false` if your clients rely on the assertion's `aud` values being present in the access token.
+
+:::note
+
+The default is `true` (omit) for self-hosted Ory Hydra (open source), Ory Enterprise License deployments, and Ory Network projects
+created after this change. Ory Network projects created earlier keep the previous behavior of copying the assertion audience; set
+`omit_assertion_audience` explicitly to change it.
+
+:::
 
 ## JWTs for client authentication
 

--- a/docs/hydra/guides/jwt.mdx
+++ b/docs/hydra/guides/jwt.mdx
@@ -139,11 +139,13 @@ In the example above, the JWT is passed in the `assertion` parameter of the requ
 The OAuth2 token endpoint will then verify the signature of the JWT and check the claims to ensure that it is valid. If the JWT is
 valid, the OAuth2 token endpoint will issue an access token that can be used to access protected resources:
 
-```json5 title="Example claims of JSON Web Token"
+```json5 title="Example claims of the issued access token"
 {
   iss: "https://$PROJECT_SLUG.projects.oryapis.com/",
   sub: "7146dd0b-f243-43ba-815c-7a00216b4823",
   scp: ["read"],
+  // The assertion's "aud" (the authorization server) is not copied into the access token by default.
+  // See "Do not use the assertion's aud value as the access token's aud value" below.
   // ...
 }
 ```
@@ -158,7 +160,7 @@ through the following steps:
 - The JWT must contain a `sub` (subject) claim that identifies the principal as the subject of the JWT (e.g., the user ID). This
   value should match the `subject` value of the trust relationship unless `allow_any_subject` is `true`.
 - The JWT must contain an `aud` (audience) claim with a value that identifies the authorization server as an intended audience.
-  The value should be the OAuth2 Token URL.
+  The value should be the OAuth2 token endpoint URL.
 - The JWT must contain an `exp` (expiration time) claim that restricts the time window during which the JWT can be used. This can
   be controlled through the `/oauth2/grant/jwt/max_ttl` setting.
 - The JWT may contain an `nbf` (not before) claim that identifies the time before which the token must not be accepted for
@@ -185,20 +187,21 @@ ory patch oauth2-config \
   --replace "/oauth2/grant/jwt/max_ttl=1h"
 ```
 
-### Assertion audience in the access token
+### Do not use the assertion's `aud` value as the access token's `aud` value
 
 Per [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523), the assertion's `aud` (audience) claim identifies the authorization server
-as the intended recipient of the JWT. It does not define the audience of the issued access token. By default, Ory therefore does
-**not** copy the assertion's `aud` values into the access token.
+as the intended recipient of the JWT. The issued access token's `aud` value should be the resource server(s) or the APIs that the
+token is meant for. By default, Ory therefore does **not** copy the assertion's `aud` values into the access token.
 
-The `omit_assertion_audience` setting controls this behavior:
+The `oauth2.grant.jwt.omit_assertion_audience` setting controls whether or not the assertion's `aud` value is copied to the access
+token:
 
 ```yaml title="hydra.yml"
 oauth2:
   grant:
     jwt:
       # true (default): the assertion audience is omitted from the access token.
-      # false: the assertion audience is copied into the access token (legacy behavior).
+      # false: the assertion audience is copied into the access token.
       omit_assertion_audience: true
 ```
 
@@ -206,9 +209,7 @@ Set it to `false` if your clients rely on the assertion's `aud` values being pre
 
 :::note
 
-The default is `true` (omit) for self-hosted Ory Hydra (open source), Ory Enterprise License deployments, and Ory Network projects
-created after this change. Ory Network projects created earlier keep the previous behavior of copying the assertion audience; set
-`omit_assertion_audience` explicitly to change it.
+The default value is `true` (omit) for Ory Hydra (Ory OSS, Ory OEL, and Ory Network deployments).
 
 :::
 


### PR DESCRIPTION
## Summary

Documents the `oauth2.grant.jwt.omit_assertion_audience` setting in the JWT profile guide (`docs/hydra/guides/jwt.mdx`).

Per [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523), the assertion's `aud` claim identifies the authorization server, not the audience of the issued access token. Ory therefore **omits the assertion audience from the access token by default**.

- Default `true` (omit) for self-hosted Ory Hydra (OSS), Ory Enterprise License, and **new** Ory Network projects.
- **Existing** Ory Network projects keep the previous copy behavior unless they set the option explicitly.
- Set `omit_assertion_audience: false` to restore the legacy behavior of copying the assertion audience.

This is a **breaking change**. Documents the behavior introduced in ory/hydra#4076 (mirrored in ory-corp/cloud#11236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)