### PR TITLE
feat: ory network cta for oss only

### DIFF
--- a/src/components/OryNetworkCta/ory-network-cta.tsx
+++ b/src/components/OryNetworkCta/ory-network-cta.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import useBaseUrl from "@docusaurus/useBaseUrl"
-
-// Resolve image via bundler so path works in dev and build (baseUrl: /docs/)
 import networkImg from "@site/src/static/img/network-cta/network.png"
+
+const toImgSrc = (m: string | { default?: string }): string =>
+  typeof m === "string" ? m : (m as { default?: string }).default ?? ""
 
 const CTA_CONFIG = {
   title: "Ory Network",
@@ -14,29 +14,25 @@ const CTA_CONFIG = {
 
 export const OryNetworkCta = () => {
   const { title, description, ctaLabel, href } = CTA_CONFIG
-  const imageSrc =
-    typeof networkImg === "string"
-      ? networkImg
-      : (networkImg as { default?: string }).default ??
-        useBaseUrl("/img/network-cta/network.png")
+  const imageSrc = toImgSrc(networkImg)
 
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="ory-network-cta mt-4 flex flex-shrink-0 flex-col rounded-xl bg-ory-bg-secondary border border-ory-border-primary p-6 shadow-md no-underline transition-shadow hover:shadow-lg xl:flex"
+      className="ory-network-cta flex flex-shrink-0 flex-col rounded-lg bg-ory-bg-secondary border border-ory-border-primary p-3 shadow-sm no-underline transition-shadow hover:shadow-md xl:flex"
     >
-      <img src={imageSrc} alt="" className="mb-4 w-full object-contain" />
-      <div className="flex flex-col gap-4">
-        <h3 className="ory-text-sm-normal m-0 text-ory-text-primary">
+      <img src={imageSrc} alt="" className="mb-3 w-full object-contain" />
+      <div className="flex flex-col gap-1">
+        <h3 className="ory-text-xs-normal m-0 text-ory-text-primary font-semibold">
           {title}
         </h3>
         <p className="ory-text-xs-normal m-0 text-ory-text-tertiary">
           {description}
         </p>
       </div>
-      <span className="mt-6 inline-flex h-8 w-full items-center justify-center rounded-ory-btn bg-ory-border-brand-tertiary font-medium text-white">
+      <span className="mt-2 inline-flex h-7 w-full items-center justify-center rounded-ory-btn bg-ory-border-brand-tertiary text-sm font-medium text-white">
         {ctaLabel}
       </span>
     </a>

--- a/src/components/OryNetworkCta/ory-network-cta.tsx
+++ b/src/components/OryNetworkCta/ory-network-cta.tsx
@@ -1,8 +1,6 @@
 import React from "react"
+// @ts-expect-error — webpack resolves PNG imports to a URL string at build time
 import networkImg from "@site/src/static/img/network-cta/network.png"
-
-const toImgSrc = (m: string | { default?: string }): string =>
-  typeof m === "string" ? m : (m as { default?: string }).default ?? ""
 
 const CTA_CONFIG = {
   title: "Ory Network",
@@ -14,8 +12,6 @@ const CTA_CONFIG = {
 
 export const OryNetworkCta = () => {
   const { title, description, ctaLabel, href } = CTA_CONFIG
-  const imageSrc = toImgSrc(networkImg)
-
   return (
     <a
       href={href}
@@ -23,7 +19,7 @@ export const OryNetworkCta = () => {
       rel="noopener noreferrer"
       className="ory-network-cta flex flex-shrink-0 flex-col rounded-lg bg-ory-bg-secondary border border-ory-border-primary p-3 shadow-sm no-underline transition-shadow hover:shadow-md xl:flex"
     >
-      <img src={imageSrc} alt="" className="mb-3 w-full object-contain" />
+      <img src={networkImg} alt="" className="mb-3 w-full object-contain" />
       <div className="flex flex-col gap-1">
         <h3 className="ory-text-xs-normal m-0 text-ory-text-primary font-semibold">
           {title}

--- a/src/theme/TOC/index.css
+++ b/src/theme/TOC/index.css
@@ -31,6 +31,13 @@ TOC wrapper.
   flex-shrink: 1;
 }
 
+.ory-network-cta-sticky {
+  position: sticky;
+  bottom: 0;
+  padding-top: 8px;
+  background: var(--ifm-background-color);
+}
+
 .kapa-widget-placeholder {
   /* Kapa widget height */
   min-height: 80px;

--- a/src/theme/TOC/index.js
+++ b/src/theme/TOC/index.js
@@ -1,13 +1,38 @@
 import React from "react"
 import TOC from "@theme-original/TOC"
+import { useLocation } from "@docusaurus/router"
+import { useDocsSidebar } from "@docusaurus/plugin-content-docs/client"
 import "./index.css"
 import { OryNetworkCta } from "../../components/OryNetworkCta/ory-network-cta"
+import { docsDeploymentFromPathname } from "../../utils/docsDeploymentFromPathname"
+
+const OSS_SIDEBAR_LABEL = "Ory Open Source"
+
+function isOssDeployment(pathname, sidebar) {
+  // Check sidebar category labels first (covers non-migrated sections)
+  if (sidebar?.items) {
+    for (const item of sidebar.items) {
+      if (item.type === "category" && item.label === OSS_SIDEBAR_LABEL)
+        return true
+    }
+  }
+  // Fall back to URL-based detection (migrated sections)
+  return docsDeploymentFromPathname(pathname) === "oss"
+}
 
 export default function TOCWrapper(props) {
+  const { pathname } = useLocation()
+  const sidebar = useDocsSidebar()
+  const isOss = isOssDeployment(pathname, sidebar)
+
   return (
     <div className="ory-toc-wrapper">
       <TOC {...props} />
-      <OryNetworkCta />
+      {isOss && (
+        <div className="ory-network-cta-sticky">
+          <OryNetworkCta />
+        </div>
+      )}
       <div className="kapa-widget-placeholder" />
     </div>
   )


### PR DESCRIPTION

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the network CTA’s layout, typography, and button sizing for improved spacing and visual alignment
  * Added a theme-consistent sticky-bottom styling for the CTA container

* **Refactor**
  * The network CTA now renders only on “Ory Open Source” documentation pages, based on the current route/sidebar context
<!-- end of auto-generated comment: release notes by coderabbit.ai -->