### PR TITLE
docs: recommend HTTP/2 for HTTP event sinks

### DIFF
--- a/docs/actions/live-events.mdx
+++ b/docs/actions/live-events.mdx
@@ -244,6 +244,9 @@ Unencrypted HTTP endpoints are not supported. Your endpoint must be able to hand
 with a 2xx status code to acknowledge successful processing of the event. HTTP redirects are _not_ followed and are treated as
 delivery failures.
 
+We strongly recommend that your endpoint supports HTTP/2. HTTP/2 multiplexing lets Ory deliver many events concurrently over a
+single connection, resulting in significantly more efficient throughput for event delivery.
+
 Authentication is possible by including credentials in the URL (HTTP Basic Authentication), for example:
 
 `https://username:password@example/com/my-event-endpoint`

--- a/docs/actions/live-events.mdx
+++ b/docs/actions/live-events.mdx
@@ -249,7 +249,7 @@ single connection, resulting in significantly more efficient throughput for even
 
 Authentication is possible by including credentials in the URL (HTTP Basic Authentication), for example:
 
-`https://username:password@example/com/my-event-endpoint`
+`https://username:password@example.com/my-event-endpoint`
 
 ### Stream to AWS SNS
 

--- a/docs/actions/live-events.mdx
+++ b/docs/actions/live-events.mdx
@@ -244,8 +244,8 @@ Unencrypted HTTP endpoints are not supported. Your endpoint must be able to hand
 with a 2xx status code to acknowledge successful processing of the event. HTTP redirects are _not_ followed and are treated as
 delivery failures.
 
-We strongly recommend that your endpoint supports HTTP/2. HTTP/2 multiplexing lets Ory deliver many events concurrently over a
-single connection, resulting in significantly more efficient throughput for event delivery.
+Your endpoint should support HTTP/2. HTTP/2 multiplexing lets Ory deliver many events concurrently over a single connection, which
+makes event delivery more efficient.
 
 Authentication is possible by including credentials in the URL (HTTP Basic Authentication), for example:
 


### PR DESCRIPTION
## Summary

Adds a strong recommendation to the [Live event streams](https://www.ory.com/docs/actions/live-events) docs that HTTP event sink endpoints support HTTP/2.

HTTP/2 multiplexing lets Ory deliver many events concurrently over a single connection, resulting in significantly more efficient throughput for event delivery.

## Changes

- `docs/actions/live-events.mdx` — added an HTTP/2 recommendation to the **Stream to HTTPS endpoint** section, right after the endpoint requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)