### PR TITLE
docs: note new identities default to active state

### DIFF
--- a/docs/kratos/manage-identities/20_create-users-identities.mdx
+++ b/docs/kratos/manage-identities/20_create-users-identities.mdx
@@ -74,6 +74,11 @@ The server response contains the created identity:
 }
 ```
 
+Newly created identities default to the `active` state, as shown by the `"state": "active"` field in the response. Active
+identities can immediately use self-service flows such as sign-in. To create an identity that can't sign in yet, set `state` to
+`inactive` in the request body. For more information, see
+[Activate and de-activate identities](/docs/identities/model/identity-state.mdx).
+
 Keep in mind that you can change the `schema_id` to reflect the schema you want to use for this identity. Similarly, the trait
 key/values depend on your schema as well. The command shown does not create a password or any other type of credential for the
 identity.

--- a/docs/kratos/manage-identities/20_create-users-identities.mdx
+++ b/docs/kratos/manage-identities/20_create-users-identities.mdx
@@ -77,7 +77,7 @@ The server response contains the created identity:
 Newly created identities default to the `active` state, as shown by the `"state": "active"` field in the response. Active
 identities can immediately use self-service flows such as sign-in. To create an identity that can't sign in yet, set `state` to
 `inactive` in the request body. For more information, see
-[Activate and de-activate identities](/docs/identities/model/identity-state.mdx).
+[Activate and de-activate identities](../../identities/model/identity-state.mdx).
 
 Keep in mind that you can change the `schema_id` to reflect the schema you want to use for this identity. Similarly, the trait
 key/values depend on your schema as well. The command shown does not create a password or any other type of credential for the


### PR DESCRIPTION
## What

Adds a short note to the **Create identities** page explaining that identities created via the admin API default to the \`active\` state (already visible as \`\"state\": \"active\"\` in the sample response, but previously unexplained), and how to create an \`inactive\` identity instead.

## Why

The sample response on this page shows \`\"state\": \"active\"\` with no explanation. This clarifies the default and points readers to the identity state page for activating/de-activating identities.

## Notes

- Verified the \`createIdentityBody\` API schema accepts a \`state\` field (enum \`active\`/\`inactive\`) in \`src/static/api.json\`, so the "set \`state\` to \`inactive\`" guidance is accurate.
- This section is still in the pre-migration \`docs/kratos/\` structure, so a plain \`/docs/...mdx\` file-path link is used (not \`SameDeploymentLink\`), consistent with neighboring pages. No migrated equivalent of this creation-flow page exists.