### PR TITLE
docs: document oauth2_login_request in courier template data

### DIFF
--- a/docs/kratos/emails-sms/05_custom-email-templates.mdx
+++ b/docs/kratos/emails-sms/05_custom-email-templates.mdx
@@ -265,6 +265,23 @@ In addition to the variables listed for each template, every template can access
 [Transient payload in templates](#transient-payload-in-templates)) and `RequestURL` (the URL of the flow request that triggered
 the email).
 
+The `login_code.valid`, `registration_code.valid`, `verification_code.valid`, and `verification.valid` templates can also access
+`OAuth2LoginRequest` when the flow was started through an OAuth2 login challenge, for example when a user signs in to an OAuth2
+client. Because Ory resolves this value server-side, it can't be forged by the end user. Use it to brand messages per OAuth2
+client instead of the end-user-controlled transient payload:
+
+| Variable                             | Description                                       |
+| ------------------------------------ | ------------------------------------------------- |
+| `OAuth2LoginRequest.Challenge`       | the OAuth2 login challenge that started the flow  |
+| `OAuth2LoginRequest.Client.ClientID` | the OAuth2 client ID                              |
+| `OAuth2LoginRequest.Client.ClientName` | the human-readable name of the OAuth2 client   |
+| `OAuth2LoginRequest.Client.ClientURI` | the URL of the OAuth2 client's homepage         |
+| `OAuth2LoginRequest.Client.LogoURI`  | the URL of the OAuth2 client's logo               |
+| `OAuth2LoginRequest.Client.Metadata` | the metadata set on the OAuth2 client             |
+
+For example: `{{ if .OAuth2LoginRequest }}{{ .OAuth2LoginRequest.Client.ClientName }}{{ end }}`. The variable is unset when the
+flow wasn't started through an OAuth2 login challenge.
+
 ```mdx-code-block
 <Tabs groupId="email-templates">
 <TabItem value="recovery_code" label="Recovery (via code)" default>

--- a/docs/kratos/emails-sms/05_custom-email-templates.mdx
+++ b/docs/kratos/emails-sms/05_custom-email-templates.mdx
@@ -270,14 +270,14 @@ The `login_code.valid`, `registration_code.valid`, `verification_code.valid`, an
 client. Because Ory resolves this value server-side, it can't be forged by the end user. Use it to brand messages per OAuth2
 client instead of the end-user-controlled transient payload:
 
-| Variable                             | Description                                       |
-| ------------------------------------ | ------------------------------------------------- |
-| `OAuth2LoginRequest.Challenge`       | the OAuth2 login challenge that started the flow  |
-| `OAuth2LoginRequest.Client.ClientID` | the OAuth2 client ID                              |
-| `OAuth2LoginRequest.Client.ClientName` | the human-readable name of the OAuth2 client   |
-| `OAuth2LoginRequest.Client.ClientURI` | the URL of the OAuth2 client's homepage         |
-| `OAuth2LoginRequest.Client.LogoURI`  | the URL of the OAuth2 client's logo               |
-| `OAuth2LoginRequest.Client.Metadata` | the metadata set on the OAuth2 client             |
+| Variable                               | Description                                      |
+| -------------------------------------- | ------------------------------------------------ |
+| `OAuth2LoginRequest.Challenge`         | the OAuth2 login challenge that started the flow |
+| `OAuth2LoginRequest.Client.ClientID`   | the OAuth2 client ID                             |
+| `OAuth2LoginRequest.Client.ClientName` | the human-readable name of the OAuth2 client     |
+| `OAuth2LoginRequest.Client.ClientURI`  | the URL of the OAuth2 client's homepage          |
+| `OAuth2LoginRequest.Client.LogoURI`    | the URL of the OAuth2 client's logo              |
+| `OAuth2LoginRequest.Client.Metadata`   | the metadata set on the OAuth2 client            |
 
 For example: `{{ if .OAuth2LoginRequest }}{{ .OAuth2LoginRequest.Client.ClientName }}{{ end }}`. The variable is unset when the
 flow wasn't started through an OAuth2 login challenge.

--- a/docs/kratos/self-hosted/03_mail-courier-http.mdx
+++ b/docs/kratos/self-hosted/03_mail-courier-http.mdx
@@ -64,12 +64,41 @@ available through a `ctx` object. `recipient` will always be the email address o
   - to
   - verification_url
   - identity
+  - oauth2_login_request (optional)
 - verification_code_invalid
   - to
 - verification_code_valid
   - to
   - verification_code
   - identity
+  - oauth2_login_request (optional)
+- login_code_valid
+  - to
+  - login_code
+  - identity
+  - oauth2_login_request (optional)
+- registration_code_valid
+  - to
+  - registration_code
+  - traits
+  - oauth2_login_request (optional)
+
+The `oauth2_login_request` field is only present when the flow was started through an OAuth2 login challenge, for example when a
+user signs in to an OAuth2 client. Because Ory resolves it server-side, it can't be forged by the end user. Use it to brand
+messages per OAuth2 client:
+
+```json
+"oauth2_login_request": {
+  "challenge": "...",
+  "client": {
+    "client_id": "...",
+    "client_name": "...",
+    "client_uri": "...",
+    "logo_uri": "...",
+    "metadata": {}
+  }
+}
+```
 
 A universal Jsonnet template that works with all flows, would look like this:
 


### PR DESCRIPTION
Kratos courier templates now receive a scoped `oauth2_login_request` object (challenge plus the initiating client's `client_id`, `client_name`, `client_uri`, `logo_uri`, and `metadata`) when a flow was started through an OAuth2 login challenge. This documents:

- the `OAuth2LoginRequest` Go template variable on the custom email templates page, and
- the `oauth2_login_request` field in the HTTP courier `template_data` (including the previously undocumented `login_code_valid` and `registration_code_valid` types).

Feature PR: ory-corp/cloud#12776 (ships with the next Kratos release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)