### PR TITLE
docs: hydra update oauth2-client updates only provided fields

### DIFF
--- a/docs/cli/ory-update-oauth2-client.md
+++ b/docs/cli/ory-update-oauth2-client.md
@@ -15,7 +15,9 @@ Update an OAuth 2.0 Client
 
 ### Synopsis
 
-This command replaces an OAuth 2.0 Client by its ID. Please be aware that this command replaces the entire client. If only the name flag (-n "my updated app") is provided, the all other fields are updated to their default values.
+This command updates an OAuth 2.0 Client by its ID. Only the fields provided as flags are changed; all other fields keep their current values.
+
+To replace the entire client with a new configuration, use the --file flag. Fields missing from the file are reset to their default values.
 
 ```
 ory update oauth2-client [id] [flags]

--- a/docs/hydra/cli/hydra-update-oauth2-client.md
+++ b/docs/hydra/cli/hydra-update-oauth2-client.md
@@ -15,7 +15,9 @@ Update an OAuth 2.0 Client
 
 ### Synopsis
 
-This command replaces an OAuth 2.0 Client by its ID. Please be aware that this command replaces the entire client. If only the name flag (-n "my updated app") is provided, the all other fields are updated to their default values.
+This command updates an OAuth 2.0 Client by its ID. Only the fields provided as flags are changed; all other fields keep their current values.
+
+To replace the entire client with a new configuration, use the --file flag. Fields missing from the file are reset to their default values.
 
 ```
 hydra update oauth2-client [id] [flags]

--- a/docs/hydra/guides/oauth2-clients.mdx
+++ b/docs/hydra/guides/oauth2-clients.mdx
@@ -122,14 +122,16 @@ To update an existing OAuth2 client, use the following methods:
 </TabItem>
 <TabItem value="cli" label="Ory CLI">
 
+To replace the entire client, pass a complete client definition from a file. Fields missing from the file are reset to their
+default values:
+
 ```
 ory update oauth2-client --project <project-id> --workspace <workspace-id> {client.id} \
-  --grant-type authorization_code --grant-type refresh_token  --grant-type client_credentials \
-  --response-type code \
-  --scope openid --scope offline_access \
-  --token-endpoint-auth-method client_secret_post \
-  --redirect-uri https://a-new-callback
+  --file client.json
 ```
+
+To change individual fields without touching the rest of the configuration, pass them as flags instead. See
+[Patch OAuth2 client](#patch-oauth2-client).
 
 </TabItem>
 <TabItem value="sdk" label="Ory SDK">
@@ -161,6 +163,17 @@ To partially update an existing OAuth2 client, use the following methods:
 2. Locate the client you want to update.
 3. Click on the **pen symbol** to update the client's configuration.
 3. When you are finished, scroll to the top and click **Save**.
+
+</TabItem>
+<TabItem value="cli" label="Ory CLI">
+
+Pass only the fields you want to change as flags. All other fields keep their current values:
+
+```
+ory update oauth2-client --project <project-id> --workspace <workspace-id> {client.id} \
+  --scope openid --scope offline_access \
+  --redirect-uri https://a-new-callback
+```
 
 </TabItem>
 <TabItem value="sdk" label="Ory SDK">


### PR DESCRIPTION
The `hydra update oauth2-client` (and, from Ory CLI v1.3.2, `ory update oauth2-client`) command now sends a partial update built from exactly the flags that were set, instead of replacing the entire client. Fields not passed as flags keep their current values; full replacement remains available via `--file`.

This PR updates the documentation accordingly:

- `docs/hydra/cli/hydra-update-oauth2-client.md`, `docs/cli/ory-update-oauth2-client.md`: new synopsis matching the updated command help text. These pages are auto-generated; the wording here matches what regeneration will produce from the new cobra `Long` text.
- `docs/hydra/guides/oauth2-clients.mdx`: the flag-based CLI example moves to the "Patch OAuth2 client" section (which is what flags now do), and the "Update OAuth2 client" section documents `--file` for full replacement.

Code change: ory-corp/cloud (hydra), PR linked from there.

## Related Issue or Design Document

Documentation improvement, no issue reference required. Related upstream request: ory/hydra#2020.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth 2.0 client update behavior when using individual command-line flags.
  * Documented that updates preserve unspecified fields when flags are used.
  * Clarified that providing a configuration file replaces the client and resets omitted fields to their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->