### PR TITLE
docs: config Kapa to open sidebar

### DIFF
--- a/src/theme/KapaWidget.tsx
+++ b/src/theme/KapaWidget.tsx
@@ -34,11 +34,12 @@ function injectKapaScript() {
   script.setAttribute("data-website-id", "e89e7663-df2c-4c7f-974a-1bf8accdd615")
   script.setAttribute("data-project-name", "Ory")
   script.setAttribute("data-project-color", "#1A237E")
+  script.setAttribute("data-view-mode", "sidebar")
   script.setAttribute(
     "data-modal-disclaimer",
     "By utilizing this chatbot, you consent to the collection and transmission of data to kapa.ai, which may include your IP address. Please be advised that your privacy and data protection are of utmost importance to us. We assure you that any data collected will be handled in compliance with applicable laws and regulations. For further details on how your data is processed and used, we encourage you to review our Privacy Policy. If you do not agree with these terms, we kindly request that you refrain from using this chatbot.",
   )
-  script.setAttribute("data-modal-title", "Ory AI Copilot")
+  script.setAttribute("data-modal-title", "Ask AI")
   script.setAttribute("data-button-text", "Ask AI")
   script.setAttribute("data-project-logo", "/docs/img/kapa-logo.png")
   script.setAttribute("data-consent-required", "true")


### PR DESCRIPTION
Configured Kapa Ask AI to open in right sidebar instead on taking over the whole screen. Users can now continue to interact with the docs site as well as asking questions in the kapa widget.

This significantly improves the user's experience.

## Checklist

- [ X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ X] I have read the [security policy](../security/policy).
- [ X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the AI widget to open in sidebar view mode.
  * Renamed the widget modal title to “Ask AI”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->