### PR TITLE
docs: add Kratos UI message 1010026 (organization SSO required)

### DIFF
--- a/docs/kratos/concepts/messages.json
+++ b/docs/kratos/concepts/messages.json
@@ -140,6 +140,11 @@
     "type": "info"
   },
   {
+    "id": 1010026,
+    "text": "Your account is managed by an organization. Please sign in using your organization's single sign-on provider.",
+    "type": "info"
+  },
+  {
     "id": 1040001,
     "text": "Sign up",
     "type": "info"

--- a/docs/kratos/concepts/ui-messages.md
+++ b/docs/kratos/concepts/ui-messages.md
@@ -260,6 +260,16 @@
 }
 ```
 
+###### Your account is managed by an organization. Please sign in using your organization's single sign-on provider. (1010026)
+
+```json
+{
+  "id": 1010026,
+  "text": "Your account is managed by an organization. Please sign in using your organization's single sign-on provider.",
+  "type": "info"
+}
+```
+
 ###### Sign up (1040001)
 
 ```json


### PR DESCRIPTION
Adds the new Kratos UI message `InfoSelfServiceLoginOrganizationSSO` (1010026) to the message reference (`ui-messages.md` and `messages.json`).

Kratos returns this message on a login flow scoped to an organization when a generic social sign-in (for example Google) resolves to an email address whose domain is claimed by an organization. Introduced by ory-corp/cloud#12924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017p7WXK99qJ8Pw6p5HHZWiH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new sign-in information message explaining that organization-managed accounts must authenticate through the organization’s single sign-on provider.
  * Documented the corresponding UI message and identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->