### PR TITLE
docs: remove nonexistent TALOS_ prefix from Talos config env vars

### DIFF
--- a/docs/talos/operate/configure.md
+++ b/docs/talos/operate/configure.md
@@ -3,10 +3,10 @@ title: Configure
 description: Configuration reference for Ory Talos
 ---
 
-Configure Ory Talos through a YAML file passed with the `--config` flag. Override any setting with `TALOS_`-prefixed environment
-variables (for example, `TALOS_DB_DSN` overrides `db.dsn`). The `--config` flag is the only configuration-related CLI flag;
-per-key flags don't exist. See the [configuration reference](../reference/config.mdx) for every key, type, default, environment
-variable mapping, and the precedence rules.
+Configure Ory Talos through a YAML file passed with the `--config` flag. Override any setting with environment variables (for
+example, `DB_DSN` overrides `db.dsn`). The `--config` flag is the only configuration-related CLI flag; per-key flags don't exist.
+See the [configuration reference](../reference/config.mdx) for every key, type, default, environment variable mapping, and the
+precedence rules.
 
 ## Hot-reload
 

--- a/docs/talos/operate/database/cockroachdb.md
+++ b/docs/talos/operate/database/cockroachdb.md
@@ -23,7 +23,7 @@ db:
 Or use an environment variable:
 
 ```shell
-export TALOS_DB_DSN="cockroach://talos@crdb:26257/talos?sslmode=verify-full&max_conns=50"
+export DB_DSN="cockroach://talos@crdb:26257/talos?sslmode=verify-full&max_conns=50"
 ```
 
 ## DSN format

--- a/docs/talos/operate/database/mysql.md
+++ b/docs/talos/operate/database/mysql.md
@@ -21,7 +21,7 @@ db:
 Or set it through an environment variable:
 
 ```shell
-export TALOS_DB_DSN="mysql://talos:secret@tcp(db:3306)/talos?tls=true&parseTime=true"
+export DB_DSN="mysql://talos:secret@tcp(db:3306)/talos?tls=true&parseTime=true"
 ```
 
 ## DSN format

--- a/docs/talos/operate/database/postgresql.md
+++ b/docs/talos/operate/database/postgresql.md
@@ -23,7 +23,7 @@ db:
 Or use an environment variable:
 
 ```shell
-export TALOS_DB_DSN="postgres://talos:secret@db:5432/talos?sslmode=require&max_conns=25&max_conn_lifetime=5m"
+export DB_DSN="postgres://talos:secret@db:5432/talos?sslmode=require&max_conns=25&max_conn_lifetime=5m"
 ```
 
 ## DSN format

--- a/docs/talos/operate/deploy/docker.md
+++ b/docs/talos/operate/deploy/docker.md
@@ -17,9 +17,9 @@ can't silently change behavior, break your configuration, or run migrations on t
 docker run -d \
   -p 4420:4420 \
   -p 4422:4422 \
-  -e TALOS_SECRETS_HMAC_CURRENT="my-secret-must-be-at-least-32-characters-long" \
-  -e TALOS_CREDENTIALS_ISSUER="http://localhost:4420" \
-  -e TALOS_DB_DSN="sqlite:///var/lib/talos/talos.db" \
+  -e SECRETS_HMAC_CURRENT="my-secret-must-be-at-least-32-characters-long" \
+  -e CREDENTIALS_ISSUER="http://localhost:4420" \
+  -e DB_DSN="sqlite:///var/lib/talos/talos.db" \
   -v talos-data:/var/lib/talos \
   oryd/talos:<version-you-want> serve
 ```

--- a/docs/talos/operate/monitoring/tracing.md
+++ b/docs/talos/operate/monitoring/tracing.md
@@ -43,10 +43,10 @@ Talos has no `tracing.tls` configuration block today. Rely on transport-layer co
 ## Environment variables
 
 ```shell
-export TALOS_TRACING_ENABLED=true
-export TALOS_TRACING_EXPORTER=otlp
-export TALOS_TRACING_ENDPOINT=otel-collector:4317
-export TALOS_TRACING_SAMPLE_RATE=0.01
+export TRACING_ENABLED=true
+export TRACING_EXPORTER=otlp
+export TRACING_ENDPOINT=otel-collector:4317
+export TRACING_SAMPLE_RATE=0.01
 ```
 
 The default `sample_rate` is `0.001` (0.1%). For a new deployment, set `0.1` (10%) or `1.0` (100%) until you have an SLO baseline,

--- a/docs/talos/operate/secrets.md
+++ b/docs/talos/operate/secrets.md
@@ -103,4 +103,4 @@ export SECRETS_HMAC_RETIRED="previous-hmac-secret-1,previous-hmac-secret-2"
 
 Inject these from a secrets manager (HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, or Kubernetes `Secret`). Never
 check secrets into version control. See the [Configuration reference](../reference/config.mdx) for the complete env-var mapping
-rules (precedence, underscore-to-dot conversion, and list parsing).
+rules (precedence, dot-to-underscore conversion, and list parsing).

--- a/docs/talos/operate/secrets.md
+++ b/docs/talos/operate/secrets.md
@@ -97,10 +97,10 @@ always stays well above the 32-char minimum.
 ## Environment variables
 
 ```shell
-export TALOS_SECRETS_HMAC_CURRENT="64-char-hmac-secret-required-for-key-operations"
-export TALOS_SECRETS_HMAC_RETIRED="previous-hmac-secret-1,previous-hmac-secret-2"
+export SECRETS_HMAC_CURRENT="64-char-hmac-secret-required-for-key-operations"
+export SECRETS_HMAC_RETIRED="previous-hmac-secret-1,previous-hmac-secret-2"
 ```
 
 Inject these from a secrets manager (HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, or Kubernetes `Secret`). Never
 check secrets into version control. See the [Configuration reference](../reference/config.mdx) for the complete env-var mapping
-rules (`TALOS_`-prefix precedence, underscore-to-dot conversion, and list parsing).
+rules (precedence, underscore-to-dot conversion, and list parsing).

--- a/docs/talos/operate/security-hardening.md
+++ b/docs/talos/operate/security-hardening.md
@@ -58,8 +58,8 @@ Talos exits with `project has no HMAC key configured` if it's unset.
 openssl rand -base64 48 | tr -d '\n+/=' | cut -c1-64
 ```
 
-Inject as `TALOS_SECRETS_HMAC_CURRENT`. Don't use `talos jwk generate hmac` for this field: it produces a JWK JSON object, not a
-raw string.
+Inject as `SECRETS_HMAC_CURRENT`. Don't use `talos jwk generate hmac` for this field: it produces a JWK JSON object, not a raw
+string.
 
 ### Pagination cursor key (derived automatically)
 

--- a/docs/talos/operate/troubleshooting.md
+++ b/docs/talos/operate/troubleshooting.md
@@ -86,7 +86,7 @@ log:
 Or via environment variable:
 
 ```shell
-export TALOS_LOG_LEVEL=debug
+export LOG_LEVEL=debug
 ```
 
 Ory Talos uses Go's `log/slog` and writes logs to stderr as JSON by default. There is no pretty-print mode. Redirect stderr to

--- a/docs/talos/reference/cli/talos-jwk-generate-ecdsa.md
+++ b/docs/talos/reference/cli/talos-jwk-generate-ecdsa.md
@@ -51,7 +51,7 @@ talos jwk generate ecdsa [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk-generate-eddsa.md
+++ b/docs/talos/reference/cli/talos-jwk-generate-eddsa.md
@@ -52,7 +52,7 @@ talos jwk generate eddsa [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk-generate-hmac.md
+++ b/docs/talos/reference/cli/talos-jwk-generate-hmac.md
@@ -50,7 +50,7 @@ talos jwk generate hmac [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk-generate-rsa.md
+++ b/docs/talos/reference/cli/talos-jwk-generate-rsa.md
@@ -54,7 +54,7 @@ talos jwk generate rsa [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk-generate.md
+++ b/docs/talos/reference/cli/talos-jwk-generate.md
@@ -27,7 +27,7 @@ Generate a new cryptographic key in JWK format for signing or encryption.
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk-get.md
+++ b/docs/talos/reference/cli/talos-jwk-get.md
@@ -45,7 +45,7 @@ talos jwk get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-jwk.md
+++ b/docs/talos/reference/cli/talos-jwk.md
@@ -28,7 +28,7 @@ algorithms.
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-batch-verify.md
+++ b/docs/talos/reference/cli/talos-keys-batch-verify.md
@@ -30,7 +30,7 @@ talos keys batch-verify [credentials...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-derive-token.md
+++ b/docs/talos/reference/cli/talos-keys-derive-token.md
@@ -36,7 +36,7 @@ talos keys derive-token [api-key-token] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-batch-import.md
+++ b/docs/talos/reference/cli/talos-keys-imported-batch-import.md
@@ -34,7 +34,7 @@ talos keys imported batch-import --file keys.json [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-delete.md
+++ b/docs/talos/reference/cli/talos-keys-imported-delete.md
@@ -29,7 +29,7 @@ talos keys imported delete [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-get.md
+++ b/docs/talos/reference/cli/talos-keys-imported-get.md
@@ -29,7 +29,7 @@ talos keys imported get [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-import.md
+++ b/docs/talos/reference/cli/talos-keys-imported-import.md
@@ -37,7 +37,7 @@ talos keys imported import [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-list.md
+++ b/docs/talos/reference/cli/talos-keys-imported-list.md
@@ -33,7 +33,7 @@ talos keys imported list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-revoke.md
+++ b/docs/talos/reference/cli/talos-keys-imported-revoke.md
@@ -31,7 +31,7 @@ talos keys imported revoke [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported-update.md
+++ b/docs/talos/reference/cli/talos-keys-imported-update.md
@@ -36,7 +36,7 @@ talos keys imported update [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-imported.md
+++ b/docs/talos/reference/cli/talos-keys-imported.md
@@ -29,7 +29,7 @@ Import, list, get, update, revoke, and delete externally-created API keys.
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issue.md
+++ b/docs/talos/reference/cli/talos-keys-issue.md
@@ -36,7 +36,7 @@ talos keys issue [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-get.md
+++ b/docs/talos/reference/cli/talos-keys-issued-get.md
@@ -29,7 +29,7 @@ talos keys issued get [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-issue.md
+++ b/docs/talos/reference/cli/talos-keys-issued-issue.md
@@ -36,7 +36,7 @@ talos keys issued issue [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-list.md
+++ b/docs/talos/reference/cli/talos-keys-issued-list.md
@@ -33,7 +33,7 @@ talos keys issued list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-revoke.md
+++ b/docs/talos/reference/cli/talos-keys-issued-revoke.md
@@ -31,7 +31,7 @@ talos keys issued revoke [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-rotate.md
+++ b/docs/talos/reference/cli/talos-keys-issued-rotate.md
@@ -32,7 +32,7 @@ talos keys issued rotate [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued-update.md
+++ b/docs/talos/reference/cli/talos-keys-issued-update.md
@@ -36,7 +36,7 @@ talos keys issued update [key-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-issued.md
+++ b/docs/talos/reference/cli/talos-keys-issued.md
@@ -29,7 +29,7 @@ Get, list, update, and rotate issued API keys.
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys-self-revoke.md
+++ b/docs/talos/reference/cli/talos-keys-self-revoke.md
@@ -32,7 +32,7 @@ talos keys self-revoke [credential] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
       --format string     Set the output format. One of table, json, yaml, json-pretty, jsonpath and jsonpointer. (default "table")
   -q, --quiet             Be quiet with output printing.

--- a/docs/talos/reference/cli/talos-keys-verify.md
+++ b/docs/talos/reference/cli/talos-keys-verify.md
@@ -34,7 +34,7 @@ talos keys verify [credential] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-keys.md
+++ b/docs/talos/reference/cli/talos-keys.md
@@ -29,7 +29,7 @@ Create, list, get, revoke, and rotate API keys.
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-migrate-down.md
+++ b/docs/talos/reference/cli/talos-migrate-down.md
@@ -50,7 +50,7 @@ talos migrate down [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-migrate-force.md
+++ b/docs/talos/reference/cli/talos-migrate-force.md
@@ -55,7 +55,7 @@ talos migrate force VERSION [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-migrate-status.md
+++ b/docs/talos/reference/cli/talos-migrate-status.md
@@ -47,7 +47,7 @@ talos migrate status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-migrate-up.md
+++ b/docs/talos/reference/cli/talos-migrate-up.md
@@ -59,7 +59,7 @@ talos migrate up [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-migrate.md
+++ b/docs/talos/reference/cli/talos-migrate.md
@@ -27,7 +27,7 @@ Run database migrations for the API Key service
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-proxy.md
+++ b/docs/talos/reference/cli/talos-proxy.md
@@ -58,7 +58,7 @@ talos proxy [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-serve-admin.md
+++ b/docs/talos/reference/cli/talos-serve-admin.md
@@ -47,7 +47,7 @@ talos serve admin [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-serve-public.md
+++ b/docs/talos/reference/cli/talos-serve-public.md
@@ -42,7 +42,7 @@ talos serve public [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos-serve.md
+++ b/docs/talos/reference/cli/talos-serve.md
@@ -45,7 +45,7 @@ talos serve [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
 ```
 

--- a/docs/talos/reference/cli/talos.md
+++ b/docs/talos/reference/cli/talos.md
@@ -24,7 +24,7 @@ It provides separate admin and public APIs for key management.
 ### Options
 
 ```
-      --config string     path to a config file (without it, only schema defaults and TALOS_-prefixed env vars apply)
+      --config string     path to a config file (without it, only schema defaults and env vars apply)
   -e, --endpoint string   HTTP server base URL including scheme, e.g. http://host:port (for client commands) (default "http://localhost:4420")
   -h, --help              help for talos
 ```

--- a/docs/talos/reference/config.mdx
+++ b/docs/talos/reference/config.mdx
@@ -11,15 +11,14 @@ Required top-level keys: `credentials`, `secrets`
 
 ## Environment variables
 
-Every configuration key can be set via an environment variable. Ory Talos uses the `TALOS_` prefix and converts dot-separated
-config paths to uppercase with underscores:
+Every configuration key can be set via an environment variable. Ory Talos converts dot-separated config paths to uppercase with
+underscores:
 
 ```
-TALOS_<SECTION>_<KEY>
+<SECTION>_<KEY>
 ```
 
-Replace dots (`.`) with underscores (`_`) and convert to uppercase. For example, `serve.http.port` becomes
-`TALOS_SERVE_HTTP_PORT`.
+Replace dots (`.`) with underscores (`_`) and convert to uppercase. For example, `serve.http.port` becomes `SERVE_HTTP_PORT`.
 
 ### Array values
 
@@ -27,11 +26,11 @@ For array-typed config keys (like `secrets.hmac.retired`), use comma separation 
 
 ```shell
 # Comma-separated
-export TALOS_SECRETS_HMAC_RETIRED="old-secret-1,old-secret-2"
+export SECRETS_HMAC_RETIRED="old-secret-1,old-secret-2"
 
 # Or indexed
-export TALOS_SECRETS_HMAC_RETIRED_0="old-secret-1"
-export TALOS_SECRETS_HMAC_RETIRED_1="old-secret-2"
+export SECRETS_HMAC_RETIRED_0="old-secret-1"
+export SECRETS_HMAC_RETIRED_1="old-secret-2"
 ```
 
 ### Precedence
@@ -48,147 +47,147 @@ Environment variables always override file-based configuration.
 
 At minimum, these must be set (via env var or config file):
 
-| Variable                     | Description                                                                  |
-| ---------------------------- | ---------------------------------------------------------------------------- |
-| `TALOS_SECRETS_HMAC_CURRENT` | HMAC secret (also derives the pagination cursor key). Minimum 32 characters. |
-| `TALOS_CREDENTIALS_ISSUER`   | Token issuer (`iss` claim) for derived tokens.                               |
+| Variable               | Description                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `SECRETS_HMAC_CURRENT` | HMAC secret (also derives the pagination cursor key). Minimum 32 characters. |
+| `CREDENTIALS_ISSUER`   | Token issuer (`iss` claim) for derived tokens.                               |
 
 ## `cache` Commercial
 
 Cache configuration.
 
-| Key                              | Type                      | Default              | Env Var                                | Description                                                                                   |
-| -------------------------------- | ------------------------- | -------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `cache.memory.max_size`          | integer                   | `104857600`          | `TALOS_CACHE_MEMORY_MAX_SIZE`          | Maximum memory usage in bytes. (restart required, Commercial)                                 |
-| `cache.memory.num_counters`      | integer                   | `10000`              | `TALOS_CACHE_MEMORY_NUM_COUNTERS`      | Number of counters for frequency estimation. (restart required, Commercial)                   |
-| `cache.redis.addrs`              | string[]                  | `["localhost:6379"]` | `TALOS_CACHE_REDIS_ADDRS`              | Redis server addresses (supports cluster/sentinel). (restart required, Commercial)            |
-| `cache.redis.conn_max_idle_time` | string                    | `5m`                 | `TALOS_CACHE_REDIS_CONN_MAX_IDLE_TIME` | Maximum duration a connection may be idle before being closed. (restart required, Commercial) |
-| `cache.redis.conn_max_lifetime`  | string                    | `30m`                | `TALOS_CACHE_REDIS_CONN_MAX_LIFETIME`  | Maximum duration a connection may be reused. (restart required, Commercial)                   |
-| `cache.redis.db`                 | integer                   | `0`                  | `TALOS_CACHE_REDIS_DB`                 | Redis database number. (restart required, Commercial)                                         |
-| `cache.redis.min_idle_conns`     | integer                   | `2`                  | `TALOS_CACHE_REDIS_MIN_IDLE_CONNS`     | Minimum number of idle connections kept open. (restart required, Commercial)                  |
-| `cache.redis.password`           | string                    | —                    | `TALOS_CACHE_REDIS_PASSWORD`           | Redis password. (restart required, Commercial)                                                |
-| `cache.redis.pool_size`          | integer                   | `100`                | `TALOS_CACHE_REDIS_POOL_SIZE`          | Connection pool size. (restart required, Commercial)                                          |
-| `cache.redis.timeout`            | string                    | `3s`                 | `TALOS_CACHE_REDIS_TIMEOUT`            | Redis operation timeout (duration string). (restart required, Commercial)                     |
-| `cache.redis.tls.enabled`        | boolean                   | `false`              | `TALOS_CACHE_REDIS_TLS_ENABLED`        | Enable TLS using the system certificate pool. (restart required, Commercial)                  |
-| `cache.ttl`                      | string                    | `5m`                 | `TALOS_CACHE_TTL`                      | Default cache TTL (duration string). (Commercial)                                             |
-| `cache.type`                     | `memory`, `redis`, `noop` | `noop`               | `TALOS_CACHE_TYPE`                     | Cache implementation type. (restart required, Commercial)                                     |
+| Key                              | Type                      | Default              | Env Var                          | Description                                                                                   |
+| -------------------------------- | ------------------------- | -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
+| `cache.memory.max_size`          | integer                   | `104857600`          | `CACHE_MEMORY_MAX_SIZE`          | Maximum memory usage in bytes. (restart required, Commercial)                                 |
+| `cache.memory.num_counters`      | integer                   | `10000`              | `CACHE_MEMORY_NUM_COUNTERS`      | Number of counters for frequency estimation. (restart required, Commercial)                   |
+| `cache.redis.addrs`              | string[]                  | `["localhost:6379"]` | `CACHE_REDIS_ADDRS`              | Redis server addresses (supports cluster/sentinel). (restart required, Commercial)            |
+| `cache.redis.conn_max_idle_time` | string                    | `5m`                 | `CACHE_REDIS_CONN_MAX_IDLE_TIME` | Maximum duration a connection may be idle before being closed. (restart required, Commercial) |
+| `cache.redis.conn_max_lifetime`  | string                    | `30m`                | `CACHE_REDIS_CONN_MAX_LIFETIME`  | Maximum duration a connection may be reused. (restart required, Commercial)                   |
+| `cache.redis.db`                 | integer                   | `0`                  | `CACHE_REDIS_DB`                 | Redis database number. (restart required, Commercial)                                         |
+| `cache.redis.min_idle_conns`     | integer                   | `2`                  | `CACHE_REDIS_MIN_IDLE_CONNS`     | Minimum number of idle connections kept open. (restart required, Commercial)                  |
+| `cache.redis.password`           | string                    | —                    | `CACHE_REDIS_PASSWORD`           | Redis password. (restart required, Commercial)                                                |
+| `cache.redis.pool_size`          | integer                   | `100`                | `CACHE_REDIS_POOL_SIZE`          | Connection pool size. (restart required, Commercial)                                          |
+| `cache.redis.timeout`            | string                    | `3s`                 | `CACHE_REDIS_TIMEOUT`            | Redis operation timeout (duration string). (restart required, Commercial)                     |
+| `cache.redis.tls.enabled`        | boolean                   | `false`              | `CACHE_REDIS_TLS_ENABLED`        | Enable TLS using the system certificate pool. (restart required, Commercial)                  |
+| `cache.ttl`                      | string                    | `5m`                 | `CACHE_TTL`                      | Default cache TTL (duration string). (Commercial)                                             |
+| `cache.type`                     | `memory`, `redis`, `noop` | `noop`               | `CACHE_TYPE`                     | Cache implementation type. (restart required, Commercial)                                     |
 
 ## `credentials`
 
 Credential configuration for API keys and derived tokens (JWT, macaroon).
 
-| Key                                                  | Type     | Default  | Env Var                                                    | Description                                                                                                                         |
-| ---------------------------------------------------- | -------- | -------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `credentials.api_keys.default_ttl`                   | string   | —        | `TALOS_CREDENTIALS_API_KEYS_DEFAULT_TTL`                   | Default API key TTL (duration string).                                                                                              |
-| `credentials.api_keys.max_ttl`                       | string   | `8760h`  | `TALOS_CREDENTIALS_API_KEYS_MAX_TTL`                       | Maximum age for API keys with timestamps.                                                                                           |
-| `credentials.api_keys.prefix.current`                | string   | `ory_ak` | `TALOS_CREDENTIALS_API_KEYS_PREFIX_CURRENT`                | Current prefix used for new API key generation.                                                                                     |
-| `credentials.api_keys.prefix.public_current`         | string   | —        | `TALOS_CREDENTIALS_API_KEYS_PREFIX_PUBLIC_CURRENT`         | Current prefix used for new PUBLIC API key generation.                                                                              |
-| `credentials.api_keys.prefix.public_retired`         | string[] | `[]`     | `TALOS_CREDENTIALS_API_KEYS_PREFIX_PUBLIC_RETIRED`         | Retired public prefixes accepted during verification for migration purposes.                                                        |
-| `credentials.api_keys.prefix.retired`                | string[] | `[]`     | `TALOS_CREDENTIALS_API_KEYS_PREFIX_RETIRED`                | Retired prefixes accepted during verification for migration purposes.                                                               |
-| `credentials.clock_skew`                             | string   | `5m`     | `TALOS_CREDENTIALS_CLOCK_SKEW`                             | Maximum clock skew tolerance for timestamp and token validation.                                                                    |
-| `credentials.derived_tokens.default_ttl`             | string   | `1h`     | `TALOS_CREDENTIALS_DERIVED_TOKENS_DEFAULT_TTL`             | Default derived token TTL applied to both JWT and macaroon tokens when no explicit TTL is provided in the request (duration string) |
-| `credentials.derived_tokens.jwt.signing_key_id`      | string   | ""       | `TALOS_CREDENTIALS_DERIVED_TOKENS_JWT_SIGNING_KEY_ID`      | Optional JWK 'kid' hint used to select the active signing key.                                                                      |
-| `credentials.derived_tokens.jwt.signing_keys.urls`   | string[] | `[]`     | `TALOS_CREDENTIALS_DERIVED_TOKENS_JWT_SIGNING_KEYS_URLS`   | List of JWKS resources.                                                                                                             |
-| `credentials.derived_tokens.macaroon.prefix.current` | string   | `mc`     | `TALOS_CREDENTIALS_DERIVED_TOKENS_MACAROON_PREFIX_CURRENT` | Current prefix used for new macaroon token generation.                                                                              |
-| `credentials.derived_tokens.macaroon.prefix.retired` | string[] | `[]`     | `TALOS_CREDENTIALS_DERIVED_TOKENS_MACAROON_PREFIX_RETIRED` | Retired prefixes accepted during macaroon verification for rotation purposes.                                                       |
-| `credentials.issuer`                                 | string   | —        | `TALOS_CREDENTIALS_ISSUER`                                 | Token issuer (iss claim) for derived tokens. (min 1 chars)                                                                          |
-| `credentials.issuer_retired`                         | string[] | `[]`     | `TALOS_CREDENTIALS_ISSUER_RETIRED`                         | Retired issuer URLs accepted during token verification.                                                                             |
+| Key                                                  | Type     | Default  | Env Var                                              | Description                                                                                                                         |
+| ---------------------------------------------------- | -------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `credentials.api_keys.default_ttl`                   | string   | —        | `CREDENTIALS_API_KEYS_DEFAULT_TTL`                   | Default API key TTL (duration string).                                                                                              |
+| `credentials.api_keys.max_ttl`                       | string   | `8760h`  | `CREDENTIALS_API_KEYS_MAX_TTL`                       | Maximum age for API keys with timestamps.                                                                                           |
+| `credentials.api_keys.prefix.current`                | string   | `ory_ak` | `CREDENTIALS_API_KEYS_PREFIX_CURRENT`                | Current prefix used for new API key generation.                                                                                     |
+| `credentials.api_keys.prefix.public_current`         | string   | —        | `CREDENTIALS_API_KEYS_PREFIX_PUBLIC_CURRENT`         | Current prefix used for new PUBLIC API key generation.                                                                              |
+| `credentials.api_keys.prefix.public_retired`         | string[] | `[]`     | `CREDENTIALS_API_KEYS_PREFIX_PUBLIC_RETIRED`         | Retired public prefixes accepted during verification for migration purposes.                                                        |
+| `credentials.api_keys.prefix.retired`                | string[] | `[]`     | `CREDENTIALS_API_KEYS_PREFIX_RETIRED`                | Retired prefixes accepted during verification for migration purposes.                                                               |
+| `credentials.clock_skew`                             | string   | `5m`     | `CREDENTIALS_CLOCK_SKEW`                             | Maximum clock skew tolerance for timestamp and token validation.                                                                    |
+| `credentials.derived_tokens.default_ttl`             | string   | `1h`     | `CREDENTIALS_DERIVED_TOKENS_DEFAULT_TTL`             | Default derived token TTL applied to both JWT and macaroon tokens when no explicit TTL is provided in the request (duration string) |
+| `credentials.derived_tokens.jwt.signing_key_id`      | string   | ""       | `CREDENTIALS_DERIVED_TOKENS_JWT_SIGNING_KEY_ID`      | Optional JWK 'kid' hint used to select the active signing key.                                                                      |
+| `credentials.derived_tokens.jwt.signing_keys.urls`   | string[] | `[]`     | `CREDENTIALS_DERIVED_TOKENS_JWT_SIGNING_KEYS_URLS`   | List of JWKS resources.                                                                                                             |
+| `credentials.derived_tokens.macaroon.prefix.current` | string   | `mc`     | `CREDENTIALS_DERIVED_TOKENS_MACAROON_PREFIX_CURRENT` | Current prefix used for new macaroon token generation.                                                                              |
+| `credentials.derived_tokens.macaroon.prefix.retired` | string[] | `[]`     | `CREDENTIALS_DERIVED_TOKENS_MACAROON_PREFIX_RETIRED` | Retired prefixes accepted during macaroon verification for rotation purposes.                                                       |
+| `credentials.issuer`                                 | string   | —        | `CREDENTIALS_ISSUER`                                 | Token issuer (iss claim) for derived tokens. (min 1 chars)                                                                          |
+| `credentials.issuer_retired`                         | string[] | `[]`     | `CREDENTIALS_ISSUER_RETIRED`                         | Retired issuer URLs accepted during token verification.                                                                             |
 
 ## `db` (restart required)
 
 Database configuration.
 
-| Key      | Type   | Default | Env Var        | Description                                                                                           |
-| -------- | ------ | ------- | -------------- | ----------------------------------------------------------------------------------------------------- |
-| `db.dsn` | string | —       | `TALOS_DB_DSN` | Database connection string with scheme and optional query parameters. (restart required, min 1 chars) |
+| Key      | Type   | Default | Env Var  | Description                                                                                           |
+| -------- | ------ | ------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `db.dsn` | string | —       | `DB_DSN` | Database connection string with scheme and optional query parameters. (restart required, min 1 chars) |
 
 ## `last_used` (restart required)
 
 Configuration for batched last_used_at timestamp updates.
 
-| Key                        | Type    | Default | Env Var                          | Description                                                                                   |
-| -------------------------- | ------- | ------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
-| `last_used.flush_interval` | string  | `30s`   | `TALOS_LAST_USED_FLUSH_INTERVAL` | Maximum time between batch flushes (Go duration string, e.g. '30s', '1m'). (restart required) |
-| `last_used.flush_size`     | integer | `100`   | `TALOS_LAST_USED_FLUSH_SIZE`     | Number of updates per shard that triggers a batch flush. (restart required)                   |
-| `last_used.num_workers`    | integer | `4`     | `TALOS_LAST_USED_NUM_WORKERS`    | Number of goroutines processing last-used batches. (restart required)                         |
-| `last_used.queue_size`     | integer | `10000` | `TALOS_LAST_USED_QUEUE_SIZE`     | Buffer size for the async last-used update queue. (restart required)                          |
+| Key                        | Type    | Default | Env Var                    | Description                                                                                   |
+| -------------------------- | ------- | ------- | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `last_used.flush_interval` | string  | `30s`   | `LAST_USED_FLUSH_INTERVAL` | Maximum time between batch flushes (Go duration string, e.g. '30s', '1m'). (restart required) |
+| `last_used.flush_size`     | integer | `100`   | `LAST_USED_FLUSH_SIZE`     | Number of updates per shard that triggers a batch flush. (restart required)                   |
+| `last_used.num_workers`    | integer | `4`     | `LAST_USED_NUM_WORKERS`    | Number of goroutines processing last-used batches. (restart required)                         |
+| `last_used.queue_size`     | integer | `10000` | `LAST_USED_QUEUE_SIZE`     | Buffer size for the async last-used update queue. (restart required)                          |
 
 ## `log` (restart required)
 
 Logging configuration.
 
-| Key          | Type                             | Default | Env Var            | Description                    |
-| ------------ | -------------------------------- | ------- | ------------------ | ------------------------------ |
-| `log.format` | `json`, `text`                   | `json`  | `TALOS_LOG_FORMAT` | Log format. (restart required) |
-| `log.level`  | `debug`, `info`, `warn`, `error` | `info`  | `TALOS_LOG_LEVEL`  | Log level. (restart required)  |
+| Key          | Type                             | Default | Env Var      | Description                    |
+| ------------ | -------------------------------- | ------- | ------------ | ------------------------------ |
+| `log.format` | `json`, `text`                   | `json`  | `LOG_FORMAT` | Log format. (restart required) |
+| `log.level`  | `debug`, `info`, `warn`, `error` | `info`  | `LOG_LEVEL`  | Log level. (restart required)  |
 
 ## `multitenancy` Commercial (restart required)
 
 Multi-tenancy configuration.
 
-| Key                     | Type     | Default | Env Var                       | Description                                                   |
-| ----------------------- | -------- | ------- | ----------------------------- | ------------------------------------------------------------- |
-| `multitenancy.enabled`  | boolean  | `false` | `TALOS_MULTITENANCY_ENABLED`  | Enable multi-tenancy support. (restart required, Commercial)  |
-| `multitenancy.networks` | object[] | `[]`    | `TALOS_MULTITENANCY_NETWORKS` | Network routing configuration. (restart required, Commercial) |
+| Key                     | Type     | Default | Env Var                 | Description                                                   |
+| ----------------------- | -------- | ------- | ----------------------- | ------------------------------------------------------------- |
+| `multitenancy.enabled`  | boolean  | `false` | `MULTITENANCY_ENABLED`  | Enable multi-tenancy support. (restart required, Commercial)  |
+| `multitenancy.networks` | object[] | `[]`    | `MULTITENANCY_NETWORKS` | Network routing configuration. (restart required, Commercial) |
 
 ## `quota`
 
 Resource caps for the current subscription tier.
 
-| Key                  | Type    | Default | Env Var                    | Description                                                                     |
-| -------------------- | ------- | ------- | -------------------------- | ------------------------------------------------------------------------------- |
-| `quota.api_keys_max` | integer | —       | `TALOS_QUOTA_API_KEYS_MAX` | Maximum number of non-revoked API keys (issued + imported) the tenant may hold. |
+| Key                  | Type    | Default | Env Var              | Description                                                                     |
+| -------------------- | ------- | ------- | -------------------- | ------------------------------------------------------------------------------- |
+| `quota.api_keys_max` | integer | —       | `QUOTA_API_KEYS_MAX` | Maximum number of non-revoked API keys (issued + imported) the tenant may hold. |
 
 ## `rate_limit` Commercial
 
 Rate limit enforcement for API keys with a RateLimitPolicy.
 
-| Key                  | Type              | Default  | Env Var                    | Description                                     |
-| -------------------- | ----------------- | -------- | -------------------------- | ----------------------------------------------- |
-| `rate_limit.backend` | `memory`, `redis` | `memory` | `TALOS_RATE_LIMIT_BACKEND` | Counter backend. (restart required, Commercial) |
-| `rate_limit.enabled` | boolean           | `false`  | `TALOS_RATE_LIMIT_ENABLED` | Enable rate limit enforcement. (Commercial)     |
+| Key                  | Type              | Default  | Env Var              | Description                                     |
+| -------------------- | ----------------- | -------- | -------------------- | ----------------------------------------------- |
+| `rate_limit.backend` | `memory`, `redis` | `memory` | `RATE_LIMIT_BACKEND` | Counter backend. (restart required, Commercial) |
+| `rate_limit.enabled` | boolean           | `false`  | `RATE_LIMIT_ENABLED` | Enable rate limit enforcement. (Commercial)     |
 
 ## `secrets`
 
 Centralized secrets management.
 
-| Key                    | Type     | Default | Env Var                      | Description                                                                          |
-| ---------------------- | -------- | ------- | ---------------------------- | ------------------------------------------------------------------------------------ |
-| `secrets.hmac.current` | string   | —       | `TALOS_SECRETS_HMAC_CURRENT` | Current HMAC secret for new key generation and checksum verification. (min 32 chars) |
-| `secrets.hmac.retired` | string[] | `[]`    | `TALOS_SECRETS_HMAC_RETIRED` | Retired HMAC secrets that remain valid for verification during rotation              |
+| Key                    | Type     | Default | Env Var                | Description                                                                          |
+| ---------------------- | -------- | ------- | ---------------------- | ------------------------------------------------------------------------------------ |
+| `secrets.hmac.current` | string   | —       | `SECRETS_HMAC_CURRENT` | Current HMAC secret for new key generation and checksum verification. (min 32 chars) |
+| `secrets.hmac.retired` | string[] | `[]`    | `SECRETS_HMAC_RETIRED` | Retired HMAC secrets that remain valid for verification during rotation              |
 
 ## `serve`
 
 Server configuration for HTTP and metrics endpoints.
 
-| Key                                               | Type                                                                                                                                                                                                     | Default                                 | Env Var                                                 | Description                                                                                                                                                                                                                                               |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serve.http.client_ip_source`                     | `CLIENT_IP_SOURCE_UNSPECIFIED`, `CLIENT_IP_SOURCE_REMOTE_ADDR`, `CLIENT_IP_SOURCE_CF_CONNECTING_IP`, `CLIENT_IP_SOURCE_X_FORWARDED_FOR`, `CLIENT_IP_SOURCE_X_REAL_IP`, `CLIENT_IP_SOURCE_TRUE_CLIENT_IP` | `CLIENT_IP_SOURCE_UNSPECIFIED`          | `TALOS_SERVE_HTTP_CLIENT_IP_SOURCE`                     | Determines which HTTP header or connection property is used to resolve the client IP for IP restriction checks. Must match your infrastructure topology. Default (unspecified) uses the TCP remote address. Hot-reloadable: read dynamically per request. |
-| `serve.http.cors.allow_credentials`               | boolean                                                                                                                                                                                                  | `false`                                 | `TALOS_SERVE_HTTP_CORS_ALLOW_CREDENTIALS`               | Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates.                                                                                                                             |
-| `serve.http.cors.allowed_headers`                 | string[]                                                                                                                                                                                                 | `["Authorization","Content-Type"]`      | `TALOS_SERVE_HTTP_CORS_ALLOWED_HEADERS`                 | A list of non simple headers the client is allowed to use with cross-domain requests. (min 1 chars)                                                                                                                                                       |
-| `serve.http.cors.allowed_methods`                 | string[]                                                                                                                                                                                                 | `["GET","POST","PUT","PATCH","DELETE"]` | `TALOS_SERVE_HTTP_CORS_ALLOWED_METHODS`                 | A list of methods the client is allowed to use with cross-domain requests.                                                                                                                                                                                |
-| `serve.http.cors.allowed_origins`                 | string[]                                                                                                                                                                                                 | `["*"]`                                 | `TALOS_SERVE_HTTP_CORS_ALLOWED_ORIGINS`                 | A list of origins a cross-domain request can be executed from.                                                                                                                                                                                            |
-| `serve.http.cors.debug`                           | boolean                                                                                                                                                                                                  | `false`                                 | `TALOS_SERVE_HTTP_CORS_DEBUG`                           | Set to true to debug server side CORS issues.                                                                                                                                                                                                             |
-| `serve.http.cors.enabled`                         | boolean                                                                                                                                                                                                  | `false`                                 | `TALOS_SERVE_HTTP_CORS_ENABLED`                         | If set to true, CORS will be enabled and preflight-requests (OPTION) will be answered.                                                                                                                                                                    |
-| `serve.http.cors.exposed_headers`                 | string[]                                                                                                                                                                                                 | `["Content-Type"]`                      | `TALOS_SERVE_HTTP_CORS_EXPOSED_HEADERS`                 | Indicates which headers are safe to expose to the API of a CORS API specification (min 1 chars)                                                                                                                                                           |
-| `serve.http.cors.max_age`                         | number                                                                                                                                                                                                   | `0`                                     | `TALOS_SERVE_HTTP_CORS_MAX_AGE`                         | Indicates how long (in seconds) the results of a preflight request can be cached.                                                                                                                                                                         |
-| `serve.http.host`                                 | string                                                                                                                                                                                                   | `0.0.0.0`                               | `TALOS_SERVE_HTTP_HOST`                                 | The host (interface) that the endpoint listens on. (restart required)                                                                                                                                                                                     |
-| `serve.http.port`                                 | integer                                                                                                                                                                                                  | `4420`                                  | `TALOS_SERVE_HTTP_PORT`                                 | The port that the endpoint listens on. (restart required)                                                                                                                                                                                                 |
-| `serve.http.request_log.exclude_health_endpoints` | boolean                                                                                                                                                                                                  | `false`                                 | `TALOS_SERVE_HTTP_REQUEST_LOG_EXCLUDE_HEALTH_ENDPOINTS` | Exclude /health/alive and /health/ready endpoints from request logs                                                                                                                                                                                       |
-| `serve.http.trust_forwarded_host`                 | boolean                                                                                                                                                                                                  | `false`                                 | `TALOS_SERVE_HTTP_TRUST_FORWARDED_HOST`                 | Trust the X-Forwarded-Host header for tenant routing. (restart required)                                                                                                                                                                                  |
-| `serve.metrics.host`                              | string                                                                                                                                                                                                   | `0.0.0.0`                               | `TALOS_SERVE_METRICS_HOST`                              | The host (interface) that the metrics endpoint listens on. (restart required, Commercial)                                                                                                                                                                 |
-| `serve.metrics.port`                              | integer                                                                                                                                                                                                  | `4422`                                  | `TALOS_SERVE_METRICS_PORT`                              | The port that the metrics endpoint listens on. (restart required, Commercial)                                                                                                                                                                             |
+| Key                                               | Type                                                                                                                                                                                                     | Default                                 | Env Var                                           | Description                                                                                                                                                                                                                                               |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serve.http.client_ip_source`                     | `CLIENT_IP_SOURCE_UNSPECIFIED`, `CLIENT_IP_SOURCE_REMOTE_ADDR`, `CLIENT_IP_SOURCE_CF_CONNECTING_IP`, `CLIENT_IP_SOURCE_X_FORWARDED_FOR`, `CLIENT_IP_SOURCE_X_REAL_IP`, `CLIENT_IP_SOURCE_TRUE_CLIENT_IP` | `CLIENT_IP_SOURCE_UNSPECIFIED`          | `SERVE_HTTP_CLIENT_IP_SOURCE`                     | Determines which HTTP header or connection property is used to resolve the client IP for IP restriction checks. Must match your infrastructure topology. Default (unspecified) uses the TCP remote address. Hot-reloadable: read dynamically per request. |
+| `serve.http.cors.allow_credentials`               | boolean                                                                                                                                                                                                  | `false`                                 | `SERVE_HTTP_CORS_ALLOW_CREDENTIALS`               | Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates.                                                                                                                             |
+| `serve.http.cors.allowed_headers`                 | string[]                                                                                                                                                                                                 | `["Authorization","Content-Type"]`      | `SERVE_HTTP_CORS_ALLOWED_HEADERS`                 | A list of non simple headers the client is allowed to use with cross-domain requests. (min 1 chars)                                                                                                                                                       |
+| `serve.http.cors.allowed_methods`                 | string[]                                                                                                                                                                                                 | `["GET","POST","PUT","PATCH","DELETE"]` | `SERVE_HTTP_CORS_ALLOWED_METHODS`                 | A list of methods the client is allowed to use with cross-domain requests.                                                                                                                                                                                |
+| `serve.http.cors.allowed_origins`                 | string[]                                                                                                                                                                                                 | `["*"]`                                 | `SERVE_HTTP_CORS_ALLOWED_ORIGINS`                 | A list of origins a cross-domain request can be executed from.                                                                                                                                                                                            |
+| `serve.http.cors.debug`                           | boolean                                                                                                                                                                                                  | `false`                                 | `SERVE_HTTP_CORS_DEBUG`                           | Set to true to debug server side CORS issues.                                                                                                                                                                                                             |
+| `serve.http.cors.enabled`                         | boolean                                                                                                                                                                                                  | `false`                                 | `SERVE_HTTP_CORS_ENABLED`                         | If set to true, CORS will be enabled and preflight-requests (OPTION) will be answered.                                                                                                                                                                    |
+| `serve.http.cors.exposed_headers`                 | string[]                                                                                                                                                                                                 | `["Content-Type"]`                      | `SERVE_HTTP_CORS_EXPOSED_HEADERS`                 | Indicates which headers are safe to expose to the API of a CORS API specification (min 1 chars)                                                                                                                                                           |
+| `serve.http.cors.max_age`                         | number                                                                                                                                                                                                   | `0`                                     | `SERVE_HTTP_CORS_MAX_AGE`                         | Indicates how long (in seconds) the results of a preflight request can be cached.                                                                                                                                                                         |
+| `serve.http.host`                                 | string                                                                                                                                                                                                   | `0.0.0.0`                               | `SERVE_HTTP_HOST`                                 | The host (interface) that the endpoint listens on. (restart required)                                                                                                                                                                                     |
+| `serve.http.port`                                 | integer                                                                                                                                                                                                  | `4420`                                  | `SERVE_HTTP_PORT`                                 | The port that the endpoint listens on. (restart required)                                                                                                                                                                                                 |
+| `serve.http.request_log.exclude_health_endpoints` | boolean                                                                                                                                                                                                  | `false`                                 | `SERVE_HTTP_REQUEST_LOG_EXCLUDE_HEALTH_ENDPOINTS` | Exclude /health/alive and /health/ready endpoints from request logs                                                                                                                                                                                       |
+| `serve.http.trust_forwarded_host`                 | boolean                                                                                                                                                                                                  | `false`                                 | `SERVE_HTTP_TRUST_FORWARDED_HOST`                 | Trust the X-Forwarded-Host header for tenant routing. (restart required)                                                                                                                                                                                  |
+| `serve.metrics.host`                              | string                                                                                                                                                                                                   | `0.0.0.0`                               | `SERVE_METRICS_HOST`                              | The host (interface) that the metrics endpoint listens on. (restart required, Commercial)                                                                                                                                                                 |
+| `serve.metrics.port`                              | integer                                                                                                                                                                                                  | `4422`                                  | `SERVE_METRICS_PORT`                              | The port that the metrics endpoint listens on. (restart required, Commercial)                                                                                                                                                                             |
 
 ## `tracing` Commercial (restart required)
 
 OpenTelemetry tracing configuration.
 
-| Key                       | Type    | Default       | Env Var                         | Description                                                                    |
-| ------------------------- | ------- | ------------- | ------------------------------- | ------------------------------------------------------------------------------ |
-| `tracing.enabled`         | boolean | `false`       | `TALOS_TRACING_ENABLED`         | Enable tracing. (restart required, Commercial)                                 |
-| `tracing.endpoint`        | string  | —             | `TALOS_TRACING_ENDPOINT`        | Trace collector endpoint. (restart required, Commercial)                       |
-| `tracing.environment`     | string  | `development` | `TALOS_TRACING_ENVIRONMENT`     | Deployment environment tag in trace attributes. (restart required, Commercial) |
-| `tracing.exporter`        | `otlp`  | —             | `TALOS_TRACING_EXPORTER`        | Trace exporter type. (restart required, Commercial)                            |
-| `tracing.sample_rate`     | number  | `0.001`       | `TALOS_TRACING_SAMPLE_RATE`     | Sampling rate (0.0 to 1.0). (restart required, Commercial)                     |
-| `tracing.service_name`    | string  | `talos`       | `TALOS_TRACING_SERVICE_NAME`    | Service name reported to OpenTelemetry. (restart required, Commercial)         |
-| `tracing.service_version` | string  | `0.0.0`       | `TALOS_TRACING_SERVICE_VERSION` | Service version reported to OpenTelemetry. (restart required, Commercial)      |
+| Key                       | Type    | Default       | Env Var                   | Description                                                                    |
+| ------------------------- | ------- | ------------- | ------------------------- | ------------------------------------------------------------------------------ |
+| `tracing.enabled`         | boolean | `false`       | `TRACING_ENABLED`         | Enable tracing. (restart required, Commercial)                                 |
+| `tracing.endpoint`        | string  | —             | `TRACING_ENDPOINT`        | Trace collector endpoint. (restart required, Commercial)                       |
+| `tracing.environment`     | string  | `development` | `TRACING_ENVIRONMENT`     | Deployment environment tag in trace attributes. (restart required, Commercial) |
+| `tracing.exporter`        | `otlp`  | —             | `TRACING_EXPORTER`        | Trace exporter type. (restart required, Commercial)                            |
+| `tracing.sample_rate`     | number  | `0.001`       | `TRACING_SAMPLE_RATE`     | Sampling rate (0.0 to 1.0). (restart required, Commercial)                     |
+| `tracing.service_name`    | string  | `talos`       | `TRACING_SERVICE_NAME`    | Service name reported to OpenTelemetry. (restart required, Commercial)         |
+| `tracing.service_version` | string  | `0.0.0`       | `TRACING_SERVICE_VERSION` | Service version reported to OpenTelemetry. (restart required, Commercial)      |


### PR DESCRIPTION
The Talos server only reads unprefixed config env vars (e.g. `SECRETS_HMAC_CURRENT`), so the documented `TALOS_`-prefixed forms are silently ignored and the published docker instructions fail. Removes the prefix from the config reference, CLI pages, and all operate guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to describe environment-variable overrides without requiring the legacy environment-variable prefix.
  * Revised operational docs and examples (database DSNs, HMAC/secrets, tracing, Docker quick start, and debug logging) to use the current environment-variable names.
  * Updated CLI help and reference pages to clarify that, when no config file is provided, schema defaults and environment variables apply (without restricting to the legacy prefix).
  * Improved consistency across guides and command-line help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->