### PR TITLE
docs: update renamed deviceauthn fields references

### DIFF
--- a/src/components/Shared/kratos/passwordless/deviceauthn/android.mdx
+++ b/src/components/Shared/kratos/passwordless/deviceauthn/android.mdx
@@ -700,10 +700,10 @@ discipline when you wire these calls.
 
 1. **Enroll** (<SameDeploymentLink to="kratos/passwordless/deviceauthn#pin-enrollment">PIN enrollment</SameDeploymentLink>) —
    `decodeNonce` the flow's `deviceauthn_nonce` node, `createSealingKey`, create a `PinCeremony`, then
-   `createPinSigningKey(alias, nonce, transportPublicKey)` and submit the `deviceauthn_register` payload with `transport_public_key` and the
-   returned chain as `certificate_chain_android`. On the response, `openSealedSecret` on the `continue_with` item, derive the
-   fingerprint with `clientKeyId(alias)`, capture the PIN, `PinVault.seal`, and persist the `PinArtifacts`. Let the `PinCeremony`
-   go out of scope so its transport key is destroyed.
+   `createPinSigningKey(alias, nonce, transportPublicKey)` and submit the `deviceauthn_register` payload with
+   `transport_public_key` and the returned chain as `certificate_chain_android`. On the response, `openSealedSecret` on the
+   `continue_with` item, derive the fingerprint with `clientKeyId(alias)`, capture the PIN, `PinVault.seal`, and persist the
+   `PinArtifacts`. Let the `PinCeremony` go out of scope so its transport key is destroyed.
 2. **Log in** (<SameDeploymentLink to="kratos/passwordless/deviceauthn#first-factor-login">First-factor
    login</SameDeploymentLink>) — `decodeNonce`, `PinVault.unseal` with the entered PIN, `pinProof(pinSecret, clientKeyId, nonce)`,
    and `sign(alias, nonce)` over the raw nonce, then submit `client_key_id`, `signature`, and `pin_proof`.

--- a/src/components/Shared/kratos/passwordless/deviceauthn/android.mdx
+++ b/src/components/Shared/kratos/passwordless/deviceauthn/android.mdx
@@ -57,9 +57,7 @@ all options; an empty list disables the check.
 
    ```json
    {
-     "delete": {
-       "client_key_id": "9c62918cbbef2e94c3a10238bd57ab196e3a2caae1a44f28b02f2d1a72b1e59c"
-     },
+     "deviceauthn_remove": "9c62918cbbef2e94c3a10238bd57ab196e3a2caae1a44f28b02f2d1a72b1e59c",
      "method": "deviceauthn"
    }
    ```
@@ -74,8 +72,7 @@ all options; an empty list disables the check.
    val body = UpdateSettingsFlowBody()
    val method = UpdateSettingsFlowWithDeviceAuthnMethod()
    method.method = "deviceauthn"
-   method.delete = UpdateSettingsFlowWithDeviceAuthnMethodDelete()
-   method.delete!!.clientKeyId = clientKeyIdToDelete
+   method.deviceauthnRemove = clientKeyIdToDelete
    body.actualInstance = method
    val updatedFlow = apiInstance.updateSettingsFlow(settingsFlow?.id, body, sessionToken, "")
    ```
@@ -90,8 +87,9 @@ all options; an empty list disables the check.
    ```json
    {
      "method": "deviceauthn",
-     "add": {
+     "deviceauthn_register": {
        "device_name": "Pixel 9",
+       "version": 1,
        "certificate_chain_android": ["...", "...", "..."]
      }
    }
@@ -113,9 +111,10 @@ all options; an empty list disables the check.
    val body = UpdateSettingsFlowBody()
    val method = UpdateSettingsFlowWithDeviceAuthnMethod()
    method.method = "deviceauthn"
-   method.add = UpdateSettingsFlowWithDeviceAuthnMethodAdd()
-   method.add!!.deviceName = "My work phone"
-   method.add!!.certificateChainAndroid = keyCertChain.map { it.encoded }.toList()
+   method.deviceauthnRegister = UpdateSettingsFlowWithDeviceAuthnMethodRegister()
+   method.deviceauthnRegister!!.deviceName = "My work phone"
+   method.deviceauthnRegister!!.version = 1
+   method.deviceauthnRegister!!.certificateChainAndroid = keyCertChain.map { it.encoded }.toList()
    body.actualInstance = method
    val updatedFlow = apiInstance.updateSettingsFlow(settingsFlow?.id, body, sessionToken, "")
 
@@ -701,7 +700,7 @@ discipline when you wire these calls.
 
 1. **Enroll** (<SameDeploymentLink to="kratos/passwordless/deviceauthn#pin-enrollment">PIN enrollment</SameDeploymentLink>) —
    `decodeNonce` the flow's `deviceauthn_nonce` node, `createSealingKey`, create a `PinCeremony`, then
-   `createPinSigningKey(alias, nonce, transportPublicKey)` and submit the `add` payload with `transport_public_key` and the
+   `createPinSigningKey(alias, nonce, transportPublicKey)` and submit the `deviceauthn_register` payload with `transport_public_key` and the
    returned chain as `certificate_chain_android`. On the response, `openSealedSecret` on the `continue_with` item, derive the
    fingerprint with `clientKeyId(alias)`, capture the PIN, `PinVault.seal`, and persist the `PinArtifacts`. Let the `PinCeremony`
    go out of scope so its transport key is destroyed.

--- a/src/components/Shared/kratos/passwordless/deviceauthn/index.mdx
+++ b/src/components/Shared/kratos/passwordless/deviceauthn/index.mdx
@@ -275,7 +275,7 @@ Runs in a settings flow under a privileged session.
    ```json
    {
      "method": "deviceauthn",
-     "add": {
+     "deviceauthn_register": {
        "device_name": "My work phone",
        "version": 1,
        "pin_protected": true,

--- a/src/components/Shared/kratos/passwordless/deviceauthn/ios.mdx
+++ b/src/components/Shared/kratos/passwordless/deviceauthn/ios.mdx
@@ -583,9 +583,9 @@ func loginWithPin(flowNonce: Data, pin: inout [UInt8], artifacts: PinArtifacts, 
 
 See <SameDeploymentLink to="kratos/passwordless/deviceauthn#pin-enrollment">PIN enrollment</SameDeploymentLink> for the payload
 reference. To wire the enrollment ceremony end to end: decode the flow nonce with `decodeNonce`, create a `PinCeremony`,
-`createPinAttestation`, submit the `deviceauthn_register` payload with `transport_public_key` and `attestation_ios`, then `openSealedSecret` on the
-returned `continue_with`, capture the PIN, `PinVault.seal`, and persist the `PinArtifacts`. Let the `PinCeremony` go out of scope
-so its transport key is destroyed.
+`createPinAttestation`, submit the `deviceauthn_register` payload with `transport_public_key` and `attestation_ios`, then
+`openSealedSecret` on the returned `continue_with`, capture the PIN, `PinVault.seal`, and persist the `PinArtifacts`. Let the
+`PinCeremony` go out of scope so its transport key is destroyed.
 
 ## Biometric keys
 

--- a/src/components/Shared/kratos/passwordless/deviceauthn/ios.mdx
+++ b/src/components/Shared/kratos/passwordless/deviceauthn/ios.mdx
@@ -67,9 +67,7 @@ all options; an empty list disables the check.
 
    ```json
    {
-     "delete": {
-       "client_key_id": "9c62918cbbef2e94c3a10238bd57ab196e3a2caae1a44f28b02f2d1a72b1e59c"
-     },
+     "deviceauthn_remove": "9c62918cbbef2e94c3a10238bd57ab196e3a2caae1a44f28b02f2d1a72b1e59c",
      "method": "deviceauthn"
    }
    ```
@@ -86,9 +84,7 @@ all options; an empty list disables the check.
    let body: UpdateSettingsFlowBody =
        .typeUpdateSettingsFlowWithDeviceAuthnMethod(
            UpdateSettingsFlowWithDeviceAuthnMethod(
-               delete: UpdateSettingsFlowWithDeviceAuthnMethodDelete(
-                   clientKeyId: clientKeyId,
-               ),
+               deviceauthnRemove: clientKeyId,
                method: "deviceauthn"
            )
        )
@@ -109,8 +105,9 @@ all options; an empty list disables the check.
    ```json
    {
      "method": "deviceauthn",
-     "add": {
+     "deviceauthn_register": {
        "device_name": "iPhone (iPhone14,5)",
+       "version": 1,
        "attestation_ios": "..."
      }
    }
@@ -132,9 +129,10 @@ all options; an empty list disables the check.
    let body: UpdateSettingsFlowBody =
        .typeUpdateSettingsFlowWithDeviceAuthnMethod(
            UpdateSettingsFlowWithDeviceAuthnMethod(
-               add: UpdateSettingsFlowWithDeviceAuthnMethodAdd(
+               deviceauthnRegister: UpdateSettingsFlowWithDeviceAuthnMethodRegister(
                    attestationIos: attestation,
                    deviceName: deviceName,
+                   version: 1,
                ),
                method: "deviceauthn"
            )
@@ -585,7 +583,7 @@ func loginWithPin(flowNonce: Data, pin: inout [UInt8], artifacts: PinArtifacts, 
 
 See <SameDeploymentLink to="kratos/passwordless/deviceauthn#pin-enrollment">PIN enrollment</SameDeploymentLink> for the payload
 reference. To wire the enrollment ceremony end to end: decode the flow nonce with `decodeNonce`, create a `PinCeremony`,
-`createPinAttestation`, submit the `add` payload with `transport_public_key` and `attestation_ios`, then `openSealedSecret` on the
+`createPinAttestation`, submit the `deviceauthn_register` payload with `transport_public_key` and `attestation_ios`, then `openSealedSecret` on the
 returned `continue_with`, capture the PIN, `PinVault.seal`, and persist the `PinArtifacts`. Let the `PinCeremony` go out of scope
 so its transport key is destroyed.
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR updates the device authentication (`deviceauthn`) documentation to match the renamed settings-flow API fields.

Changes:

- Key registration: the `add` payload field is renamed to `deviceauthn_register`, and the SDK
  model `UpdateSettingsFlowWithDeviceAuthnMethodAdd` is now
  `UpdateSettingsFlowWithDeviceAuthnMethodRegister` (`method.add` → `method.deviceauthnRegister`).
- Key removal: the `delete` object with a nested `client_key_id` is replaced by a flat
  `deviceauthn_remove` string field, removing the need for the
  `UpdateSettingsFlowWithDeviceAuthnMethodDelete` wrapper in the SDKs.
- The Android and iOS registration examples now include the required `version: 1` field,
  aligning them with the payload reference in the overview page.

All JSON payloads, Kotlin/Swift SDK snippets, and prose references to the old field names
were updated accordingly.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
